### PR TITLE
Movies: KinoPoisk id fallback + /library/movies/unscrobblable

### DIFF
--- a/MyShows/Api/HistoryController.cs
+++ b/MyShows/Api/HistoryController.cs
@@ -1,7 +1,13 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Mime;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -11,11 +17,20 @@ namespace MyShows.Api
 {
     [ApiController]
     [Authorize]
-    [Route("MyShows/v1/history")]
+    [Route("MyShows/v1")]
     [Produces(MediaTypeNames.Application.Json)]
     public class HistoryController : ControllerBase
     {
-        [HttpGet("stats")]
+        private readonly ILibraryManager _libraryManager;
+        private readonly IUserManager _userManager;
+
+        public HistoryController(ILibraryManager libraryManager, IUserManager userManager)
+        {
+            _libraryManager = libraryManager;
+            _userManager = userManager;
+        }
+
+        [HttpGet("history/stats")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<ActionResult<HistoryStats>> GetStats(
             [FromQuery] int topShows = 10,
@@ -31,7 +46,7 @@ namespace MyShows.Api
             return Ok(stats);
         }
 
-        [HttpGet("episodes/recent")]
+        [HttpGet("history/episodes/recent")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<ActionResult> GetRecentEpisodes(
             [FromQuery] int limit = 20,
@@ -48,7 +63,7 @@ namespace MyShows.Api
             return Ok(new { items = episodes });
         }
 
-        [HttpGet("shows/recent")]
+        [HttpGet("history/shows/recent")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<ActionResult> GetRecentShows(
             [FromQuery] int limit = 15,
@@ -65,7 +80,7 @@ namespace MyShows.Api
             return Ok(new { items = shows });
         }
 
-        [HttpGet("movies")]
+        [HttpGet("history/movies")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<ActionResult> GetMovies(
             [FromQuery] int limit = 30,
@@ -81,6 +96,69 @@ namespace MyShows.Api
 
             var movies = await store.GetMovies(targetUser, limit, onlyFinished);
             return Ok(new { items = movies });
+        }
+
+        [HttpGet("library/movies/unscrobblable")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public ActionResult GetUnscrobblableMovies()
+        {
+            var caller = CurrentUserId();
+            if (caller == null) return Forbid();
+            if (!Guid.TryParseExact(caller, "N", out var userGuid)) return Forbid();
+            var user = _userManager.GetUserById(userGuid);
+            if (user == null) return Forbid();
+
+            var allMovies = _libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = new[] { BaseItemKind.Movie },
+                Recursive = true,
+                IsVirtualItem = false,
+            }).OfType<Movie>().ToList();
+
+            var missing = new List<UnscrobblableMovie>();
+            var kpOnly = new List<UnscrobblableMovie>();
+
+            foreach (var movie in allMovies)
+            {
+                var tmdb = movie.GetTmdbId();
+                var kp = movie.GetKinopoiskId();
+                if (!string.IsNullOrEmpty(tmdb)) continue;
+
+                var dto = new UnscrobblableMovie
+                {
+                    ItemId = movie.Id.ToString("N"),
+                    Title = movie.Name,
+                    OriginalTitle = movie.OriginalTitle,
+                    Year = movie.ProductionYear,
+                    Path = movie.Path,
+                    KinopoiskId = kp,
+                };
+
+                if (string.IsNullOrEmpty(kp)) missing.Add(dto);
+                else kpOnly.Add(dto);
+            }
+
+            missing.Sort((a, b) => string.Compare(a.Title, b.Title, StringComparison.OrdinalIgnoreCase));
+            kpOnly.Sort((a, b) => string.Compare(a.Title, b.Title, StringComparison.OrdinalIgnoreCase));
+
+            return Ok(new
+            {
+                total = allMovies.Count,
+                noExternalId = missing.Count,
+                kinopoiskOnly = kpOnly.Count,
+                noExternalIdItems = missing,
+                kinopoiskOnlyItems = kpOnly,
+            });
+        }
+
+        public class UnscrobblableMovie
+        {
+            public string ItemId { get; set; }
+            public string Title { get; set; }
+            public string OriginalTitle { get; set; }
+            public int? Year { get; set; }
+            public string Path { get; set; }
+            public string KinopoiskId { get; set; }
         }
 
         private string ResolveTargetUserId(string requested)

--- a/MyShows/Api/HistoryController.cs
+++ b/MyShows/Api/HistoryController.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Net.Mime;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using MyShows.Journal;
+
+namespace MyShows.Api
+{
+    [ApiController]
+    [Authorize]
+    [Route("MyShows/v1/history")]
+    [Produces(MediaTypeNames.Application.Json)]
+    public class HistoryController : ControllerBase
+    {
+        [HttpGet("stats")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public async Task<ActionResult<HistoryStats>> GetStats(
+            [FromQuery] int topShows = 10,
+            [FromQuery] string userId = null)
+        {
+            var targetUser = ResolveTargetUserId(userId);
+            if (targetUser == null) return Forbid();
+
+            var store = JournalAccessor.TryOpen();
+            if (store == null) return NotFound(new { error = "Journal not initialised. Run pull-task first." });
+
+            var stats = await store.GetStats(targetUser, topShows);
+            return Ok(stats);
+        }
+
+        [HttpGet("episodes/recent")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public async Task<ActionResult> GetRecentEpisodes(
+            [FromQuery] int limit = 20,
+            [FromQuery] string userId = null)
+        {
+            var targetUser = ResolveTargetUserId(userId);
+            if (targetUser == null) return Forbid();
+            if (limit <= 0 || limit > 500) limit = 20;
+
+            var store = JournalAccessor.TryOpen();
+            if (store == null) return NotFound(new { error = "Journal not initialised. Run pull-task first." });
+
+            var episodes = await store.GetRecentEpisodes(targetUser, limit);
+            return Ok(new { items = episodes });
+        }
+
+        private string ResolveTargetUserId(string requested)
+        {
+            var caller = CurrentUserId();
+            if (caller == null) return null;
+
+            if (string.IsNullOrWhiteSpace(requested)) return caller;
+
+            var requestedNorm = NormaliseUserId(requested);
+            if (requestedNorm == null) return null;
+            if (requestedNorm == caller) return caller;
+            if (IsAdmin()) return requestedNorm;
+            return null;
+        }
+
+        private string CurrentUserId()
+        {
+            var raw = User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                      ?? User.FindFirst("Jellyfin-UserId")?.Value;
+            return NormaliseUserId(raw);
+        }
+
+        private bool IsAdmin() =>
+            User.IsInRole("Administrator")
+            || string.Equals(User.FindFirst("Jellyfin-IsAdmin")?.Value, "true", StringComparison.OrdinalIgnoreCase);
+
+        private static string NormaliseUserId(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) return null;
+            return Guid.TryParse(raw, out var guid) ? guid.ToString("N").ToLowerInvariant() : null;
+        }
+    }
+}

--- a/MyShows/Api/HistoryController.cs
+++ b/MyShows/Api/HistoryController.cs
@@ -48,6 +48,41 @@ namespace MyShows.Api
             return Ok(new { items = episodes });
         }
 
+        [HttpGet("shows/recent")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public async Task<ActionResult> GetRecentShows(
+            [FromQuery] int limit = 15,
+            [FromQuery] string userId = null)
+        {
+            var targetUser = ResolveTargetUserId(userId);
+            if (targetUser == null) return Forbid();
+            if (limit <= 0 || limit > 100) limit = 15;
+
+            var store = JournalAccessor.TryOpen();
+            if (store == null) return NotFound(new { error = "Journal not initialised. Run pull-task first." });
+
+            var shows = await store.GetRecentShows(targetUser, limit);
+            return Ok(new { items = shows });
+        }
+
+        [HttpGet("movies")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public async Task<ActionResult> GetMovies(
+            [FromQuery] int limit = 30,
+            [FromQuery] bool onlyFinished = true,
+            [FromQuery] string userId = null)
+        {
+            var targetUser = ResolveTargetUserId(userId);
+            if (targetUser == null) return Forbid();
+            if (limit <= 0 || limit > 500) limit = 30;
+
+            var store = JournalAccessor.TryOpen();
+            if (store == null) return NotFound(new { error = "Journal not initialised. Run pull-task first." });
+
+            var movies = await store.GetMovies(targetUser, limit, onlyFinished);
+            return Ok(new { items = movies });
+        }
+
         private string ResolveTargetUserId(string requested)
         {
             var caller = CurrentUserId();

--- a/MyShows/Configuration/UserConfig.cs
+++ b/MyShows/Configuration/UserConfig.cs
@@ -38,6 +38,11 @@ namespace MyShows.Configuration
         public int ScrobbleAt { get; set; } = 90;
 
         /// <summary>
+        /// Opt-in: pull watched state from MyShows back into Jellyfin (via scheduled task).
+        /// </summary>
+        public bool PullWatchedFromMyShows { get; set; } = false;
+
+        /// <summary>
         /// Ensure OAuth access_token is vaild and refresh if it's not.
         /// </summary>
         /// <param name="

--- a/MyShows/Extensions.cs
+++ b/MyShows/Extensions.cs
@@ -25,6 +25,12 @@ namespace MyShows
             return (-1, null);
         }
 
+        public static string GetTmdbId(this IHasProviderIds item)
+        {
+            var tmdb = item.GetProviderId(MetadataProvider.Tmdb);
+            return string.IsNullOrEmpty(tmdb) ? null : tmdb;
+        }
+
         public static async Task<T> DeserializeFromHttp<T>(HttpResponseMessage response)
         {
             var contentStream = await response.Content.ReadAsStreamAsync();

--- a/MyShows/Extensions.cs
+++ b/MyShows/Extensions.cs
@@ -31,6 +31,23 @@ namespace MyShows
             return string.IsNullOrEmpty(tmdb) ? null : tmdb;
         }
 
+        public static string GetKinopoiskId(this IHasProviderIds item)
+        {
+            var kp = item.GetProviderId("kinopoisk");
+            return string.IsNullOrEmpty(kp) ? null : kp;
+        }
+
+        public static (string id, string source) GetBestMovieExternalId(this IHasProviderIds item)
+        {
+            var tmdb = item.GetTmdbId();
+            if (!string.IsNullOrEmpty(tmdb)) return (tmdb, "tmdb");
+
+            var kp = item.GetKinopoiskId();
+            if (!string.IsNullOrEmpty(kp)) return (kp, "kinopoisk");
+
+            return (null, null);
+        }
+
         public static async Task<T> DeserializeFromHttp<T>(HttpResponseMessage response)
         {
             var contentStream = await response.Content.ReadAsStreamAsync();

--- a/MyShows/Journal/JournalAccessor.cs
+++ b/MyShows/Journal/JournalAccessor.cs
@@ -1,0 +1,33 @@
+using System.IO;
+
+namespace MyShows.Journal
+{
+    internal static class JournalAccessor
+    {
+        private static JournalStore _instance;
+        private static readonly object _lock = new();
+
+        public static JournalStore Open()
+        {
+            if (_instance != null) return _instance;
+            lock (_lock)
+            {
+                if (_instance != null) return _instance;
+                var dir = Plugin.Instance?.DataFolderPath
+                    ?? throw new System.InvalidOperationException("MyShows plugin instance is not initialised");
+                var dbPath = Path.Combine(dir, "journal.db");
+                _instance = new JournalStore(dbPath);
+                return _instance;
+            }
+        }
+
+        public static JournalStore TryOpen()
+        {
+            var dir = Plugin.Instance?.DataFolderPath;
+            if (string.IsNullOrEmpty(dir)) return null;
+            var dbPath = Path.Combine(dir, "journal.db");
+            if (!File.Exists(dbPath)) return null;
+            return Open();
+        }
+    }
+}

--- a/MyShows/Journal/JournalModels.cs
+++ b/MyShows/Journal/JournalModels.cs
@@ -9,6 +9,7 @@ namespace MyShows.Journal
         public string Title { get; set; }
         public string TitleOriginal { get; set; }
         public int? Year { get; set; }
+        public int? TotalSeasons { get; set; }
         public string Status { get; set; }
         public string WatchStatus { get; set; }
         public int WatchedEpisodes { get; set; }
@@ -67,5 +68,30 @@ namespace MyShows.Journal
         public int SeasonNumber { get; set; }
         public int EpisodeNumber { get; set; }
         public string WatchDate { get; set; }
+    }
+
+    public class RecentShow
+    {
+        public int ShowId { get; set; }
+        public string Title { get; set; }
+        public string TitleOriginal { get; set; }
+        public int? Year { get; set; }
+        public int? TotalSeasons { get; set; }
+        public string WatchStatus { get; set; }
+        public int WatchedEpisodes { get; set; }
+        public int TotalEpisodes { get; set; }
+        public int? LastSeason { get; set; }
+        public int? LastEpisode { get; set; }
+        public string LastWatchDate { get; set; }
+    }
+
+    public class JournaledMovie
+    {
+        public int MovieId { get; set; }
+        public string TmdbId { get; set; }
+        public string Title { get; set; }
+        public string WatchStatus { get; set; }
+        public string WatchDate { get; set; }
+        public long LastSyncedAtUnix { get; set; }
     }
 }

--- a/MyShows/Journal/JournalModels.cs
+++ b/MyShows/Journal/JournalModels.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+
+namespace MyShows.Journal
+{
+    internal class JournalShow
+    {
+        public int ShowId { get; set; }
+        public string Title { get; set; }
+        public string TitleOriginal { get; set; }
+        public int? Year { get; set; }
+        public string Status { get; set; }
+        public string WatchStatus { get; set; }
+        public int WatchedEpisodes { get; set; }
+        public int TotalEpisodes { get; set; }
+        public double? Rating { get; set; }
+    }
+
+    internal class JournalEpisode
+    {
+        public int EpisodeId { get; set; }
+        public int ShowId { get; set; }
+        public int SeasonNumber { get; set; }
+        public int EpisodeNumber { get; set; }
+        public DateTimeOffset? WatchDate { get; set; }
+        public double? Rating { get; set; }
+        public bool IsFavorite { get; set; }
+    }
+
+    internal class JournalMovie
+    {
+        public int MovieId { get; set; }
+        public string TmdbId { get; set; }
+        public string Title { get; set; }
+        public string WatchStatus { get; set; }
+        public DateTimeOffset? WatchDate { get; set; }
+        public double? Rating { get; set; }
+    }
+
+    public class HistoryStats
+    {
+        public string JellyfinUserId { get; set; }
+        public int ShowsTotal { get; set; }
+        public int ShowsFinished { get; set; }
+        public int ShowsWatching { get; set; }
+        public int EpisodesWatched { get; set; }
+        public int EpisodesAired { get; set; }
+        public int MoviesWatched { get; set; }
+        public long LastSyncedAtUnix { get; set; }
+        public IReadOnlyList<HistoryStatsTopShow> TopShows { get; set; }
+    }
+
+    public class HistoryStatsTopShow
+    {
+        public int ShowId { get; set; }
+        public string Title { get; set; }
+        public int? Year { get; set; }
+        public int WatchedEpisodes { get; set; }
+        public int TotalEpisodes { get; set; }
+        public string WatchStatus { get; set; }
+    }
+
+    public class RecentEpisode
+    {
+        public int ShowId { get; set; }
+        public string ShowTitle { get; set; }
+        public int SeasonNumber { get; set; }
+        public int EpisodeNumber { get; set; }
+        public string WatchDate { get; set; }
+    }
+}

--- a/MyShows/Journal/JournalStore.cs
+++ b/MyShows/Journal/JournalStore.cs
@@ -28,6 +28,7 @@ namespace MyShows.Journal
             using var cmd = conn.CreateCommand();
             cmd.CommandText = @"
 PRAGMA journal_mode=WAL;
+PRAGMA foreign_keys=OFF;
 
 CREATE TABLE IF NOT EXISTS myshows_shows (
     show_id           INTEGER NOT NULL,
@@ -35,6 +36,7 @@ CREATE TABLE IF NOT EXISTS myshows_shows (
     title             TEXT    NOT NULL,
     title_original    TEXT,
     year              INTEGER,
+    total_seasons     INTEGER,
     status            TEXT,
     watch_status      TEXT,
     watched_episodes  INTEGER NOT NULL DEFAULT 0,
@@ -75,6 +77,34 @@ CREATE INDEX IF NOT EXISTS idx_eps_user_watch
     ON myshows_episodes(jellyfin_user_id, watch_date DESC);
 ";
             cmd.ExecuteNonQuery();
+
+            using var migrate = conn.CreateCommand();
+            migrate.CommandText = "PRAGMA table_info(myshows_shows);";
+            var hasTotalSeasons = false;
+            using (var r = migrate.ExecuteReader())
+            {
+                while (r.Read())
+                {
+                    if (string.Equals(r.GetString(1), "total_seasons", StringComparison.OrdinalIgnoreCase))
+                    {
+                        hasTotalSeasons = true;
+                        break;
+                    }
+                }
+            }
+            if (!hasTotalSeasons)
+            {
+                using var alter = conn.CreateCommand();
+                alter.CommandText = "ALTER TABLE myshows_shows ADD COLUMN total_seasons INTEGER;";
+                try
+                {
+                    alter.ExecuteNonQuery();
+                }
+                catch (Microsoft.Data.Sqlite.SqliteException)
+                {
+                    // racing with another instance or column already exists
+                }
+            }
         }
 
         public async Task UpsertShows(string userId, IReadOnlyList<JournalShow> shows)
@@ -86,14 +116,15 @@ CREATE INDEX IF NOT EXISTS idx_eps_user_watch
             await using var cmd = conn.CreateCommand();
             cmd.Transaction = tx;
             cmd.CommandText = @"
-INSERT INTO myshows_shows (show_id, jellyfin_user_id, title, title_original, year, status,
-                            watch_status, watched_episodes, total_episodes, rating, last_synced_at)
-VALUES ($show_id, $user, $title, $title_original, $year, $status,
-        $watch_status, $we, $te, $rating, $now)
+INSERT INTO myshows_shows (show_id, jellyfin_user_id, title, title_original, year, total_seasons,
+                            status, watch_status, watched_episodes, total_episodes, rating, last_synced_at)
+VALUES ($show_id, $user, $title, $title_original, $year, $total_seasons,
+        $status, $watch_status, $we, $te, $rating, $now)
 ON CONFLICT(show_id, jellyfin_user_id) DO UPDATE SET
     title            = excluded.title,
     title_original   = excluded.title_original,
     year             = excluded.year,
+    total_seasons    = excluded.total_seasons,
     status           = excluded.status,
     watch_status     = excluded.watch_status,
     watched_episodes = excluded.watched_episodes,
@@ -106,6 +137,7 @@ ON CONFLICT(show_id, jellyfin_user_id) DO UPDATE SET
             var pTitle = cmd.CreateParameter(); pTitle.ParameterName = "$title"; cmd.Parameters.Add(pTitle);
             var pTitleOrig = cmd.CreateParameter(); pTitleOrig.ParameterName = "$title_original"; cmd.Parameters.Add(pTitleOrig);
             var pYear = cmd.CreateParameter(); pYear.ParameterName = "$year"; cmd.Parameters.Add(pYear);
+            var pTotalSeasons = cmd.CreateParameter(); pTotalSeasons.ParameterName = "$total_seasons"; cmd.Parameters.Add(pTotalSeasons);
             var pStatus = cmd.CreateParameter(); pStatus.ParameterName = "$status"; cmd.Parameters.Add(pStatus);
             var pWatchStatus = cmd.CreateParameter(); pWatchStatus.ParameterName = "$watch_status"; cmd.Parameters.Add(pWatchStatus);
             var pWe = cmd.CreateParameter(); pWe.ParameterName = "$we"; cmd.Parameters.Add(pWe);
@@ -121,6 +153,7 @@ ON CONFLICT(show_id, jellyfin_user_id) DO UPDATE SET
                 pTitle.Value = s.Title ?? string.Empty;
                 pTitleOrig.Value = (object)s.TitleOriginal ?? DBNull.Value;
                 pYear.Value = (object)s.Year ?? DBNull.Value;
+                pTotalSeasons.Value = (object)s.TotalSeasons ?? DBNull.Value;
                 pStatus.Value = (object)s.Status ?? DBNull.Value;
                 pWatchStatus.Value = (object)s.WatchStatus ?? DBNull.Value;
                 pWe.Value = s.WatchedEpisodes;
@@ -320,6 +353,83 @@ WHERE jellyfin_user_id = $user AND show_id = $show;";
                     when = dt;
                 }
                 result[key] = when;
+            }
+            return result;
+        }
+
+        public async Task<IReadOnlyList<RecentShow>> GetRecentShows(string userId, int limit)
+        {
+            var result = new List<RecentShow>(limit);
+            await using var conn = Open();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+WITH latest AS (
+    SELECT show_id,
+           season_number,
+           episode_number,
+           watch_date,
+           ROW_NUMBER() OVER (PARTITION BY show_id ORDER BY watch_date DESC) AS rn
+    FROM myshows_episodes
+    WHERE jellyfin_user_id = $user AND watch_date IS NOT NULL
+)
+SELECT s.show_id, s.title, s.title_original, s.year, s.total_seasons, s.watch_status,
+       s.watched_episodes, s.total_episodes,
+       l.season_number, l.episode_number, l.watch_date
+FROM myshows_shows s
+JOIN latest l ON l.show_id = s.show_id AND l.rn = 1
+WHERE s.jellyfin_user_id = $user
+ORDER BY l.watch_date DESC
+LIMIT $limit;";
+            cmd.Parameters.AddWithValue("$user", userId);
+            cmd.Parameters.AddWithValue("$limit", limit);
+            await using var r = await cmd.ExecuteReaderAsync();
+            while (await r.ReadAsync())
+            {
+                result.Add(new RecentShow
+                {
+                    ShowId = r.GetInt32(0),
+                    Title = r.IsDBNull(1) ? "?" : r.GetString(1),
+                    TitleOriginal = r.IsDBNull(2) ? null : r.GetString(2),
+                    Year = r.IsDBNull(3) ? (int?)null : r.GetInt32(3),
+                    TotalSeasons = r.IsDBNull(4) ? (int?)null : r.GetInt32(4),
+                    WatchStatus = r.IsDBNull(5) ? null : r.GetString(5),
+                    WatchedEpisodes = r.GetInt32(6),
+                    TotalEpisodes = r.GetInt32(7),
+                    LastSeason = r.IsDBNull(8) ? (int?)null : r.GetInt32(8),
+                    LastEpisode = r.IsDBNull(9) ? (int?)null : r.GetInt32(9),
+                    LastWatchDate = r.IsDBNull(10) ? null : r.GetString(10),
+                });
+            }
+            return result;
+        }
+
+        public async Task<IReadOnlyList<JournaledMovie>> GetMovies(string userId, int limit, bool onlyFinished)
+        {
+            var result = new List<JournaledMovie>(limit);
+            await using var conn = Open();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+SELECT movie_id, tmdb_id, title, watch_status, watch_date, last_synced_at
+FROM myshows_movies
+WHERE jellyfin_user_id = $user
+  AND ($all = 1 OR watch_status = 'finished')
+ORDER BY COALESCE(watch_date, '') DESC, last_synced_at DESC
+LIMIT $limit;";
+            cmd.Parameters.AddWithValue("$user", userId);
+            cmd.Parameters.AddWithValue("$all", onlyFinished ? 0 : 1);
+            cmd.Parameters.AddWithValue("$limit", limit);
+            await using var r = await cmd.ExecuteReaderAsync();
+            while (await r.ReadAsync())
+            {
+                result.Add(new JournaledMovie
+                {
+                    MovieId = r.GetInt32(0),
+                    TmdbId = r.IsDBNull(1) ? null : r.GetString(1),
+                    Title = r.IsDBNull(2) ? null : r.GetString(2),
+                    WatchStatus = r.IsDBNull(3) ? null : r.GetString(3),
+                    WatchDate = r.IsDBNull(4) ? null : r.GetString(4),
+                    LastSyncedAtUnix = r.GetInt64(5),
+                });
             }
             return result;
         }

--- a/MyShows/Journal/JournalStore.cs
+++ b/MyShows/Journal/JournalStore.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+
+namespace MyShows.Journal
+{
+    internal class JournalStore
+    {
+        private readonly string _connectionString;
+
+        public JournalStore(string dbPath)
+        {
+            var dir = Path.GetDirectoryName(dbPath);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+            _connectionString = $"Data Source={dbPath}";
+            EnsureSchema();
+        }
+
+        private void EnsureSchema()
+        {
+            using var conn = Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+PRAGMA journal_mode=WAL;
+
+CREATE TABLE IF NOT EXISTS myshows_shows (
+    show_id           INTEGER NOT NULL,
+    jellyfin_user_id  TEXT    NOT NULL,
+    title             TEXT    NOT NULL,
+    title_original    TEXT,
+    year              INTEGER,
+    status            TEXT,
+    watch_status      TEXT,
+    watched_episodes  INTEGER NOT NULL DEFAULT 0,
+    total_episodes    INTEGER NOT NULL DEFAULT 0,
+    rating            REAL,
+    last_synced_at    INTEGER NOT NULL,
+    PRIMARY KEY (show_id, jellyfin_user_id)
+);
+
+CREATE TABLE IF NOT EXISTS myshows_episodes (
+    episode_id        INTEGER NOT NULL,
+    jellyfin_user_id  TEXT    NOT NULL,
+    show_id           INTEGER NOT NULL,
+    season_number     INTEGER NOT NULL,
+    episode_number    INTEGER NOT NULL,
+    watch_date        TEXT,
+    rating            REAL,
+    is_favorite       INTEGER NOT NULL DEFAULT 0,
+    last_synced_at    INTEGER NOT NULL,
+    PRIMARY KEY (episode_id, jellyfin_user_id)
+);
+
+CREATE TABLE IF NOT EXISTS myshows_movies (
+    movie_id          INTEGER NOT NULL,
+    jellyfin_user_id  TEXT    NOT NULL,
+    tmdb_id           TEXT,
+    title             TEXT,
+    watch_status      TEXT,
+    watch_date        TEXT,
+    rating            REAL,
+    last_synced_at    INTEGER NOT NULL,
+    PRIMARY KEY (movie_id, jellyfin_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_eps_show_user
+    ON myshows_episodes(show_id, jellyfin_user_id);
+CREATE INDEX IF NOT EXISTS idx_eps_user_watch
+    ON myshows_episodes(jellyfin_user_id, watch_date DESC);
+";
+            cmd.ExecuteNonQuery();
+        }
+
+        public async Task UpsertShows(string userId, IReadOnlyList<JournalShow> shows)
+        {
+            if (shows.Count == 0) return;
+            var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            await using var conn = Open();
+            await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.Transaction = tx;
+            cmd.CommandText = @"
+INSERT INTO myshows_shows (show_id, jellyfin_user_id, title, title_original, year, status,
+                            watch_status, watched_episodes, total_episodes, rating, last_synced_at)
+VALUES ($show_id, $user, $title, $title_original, $year, $status,
+        $watch_status, $we, $te, $rating, $now)
+ON CONFLICT(show_id, jellyfin_user_id) DO UPDATE SET
+    title            = excluded.title,
+    title_original   = excluded.title_original,
+    year             = excluded.year,
+    status           = excluded.status,
+    watch_status     = excluded.watch_status,
+    watched_episodes = excluded.watched_episodes,
+    total_episodes   = excluded.total_episodes,
+    rating           = excluded.rating,
+    last_synced_at   = excluded.last_synced_at;";
+
+            var pShow = cmd.CreateParameter(); pShow.ParameterName = "$show_id"; cmd.Parameters.Add(pShow);
+            var pUser = cmd.CreateParameter(); pUser.ParameterName = "$user"; cmd.Parameters.Add(pUser);
+            var pTitle = cmd.CreateParameter(); pTitle.ParameterName = "$title"; cmd.Parameters.Add(pTitle);
+            var pTitleOrig = cmd.CreateParameter(); pTitleOrig.ParameterName = "$title_original"; cmd.Parameters.Add(pTitleOrig);
+            var pYear = cmd.CreateParameter(); pYear.ParameterName = "$year"; cmd.Parameters.Add(pYear);
+            var pStatus = cmd.CreateParameter(); pStatus.ParameterName = "$status"; cmd.Parameters.Add(pStatus);
+            var pWatchStatus = cmd.CreateParameter(); pWatchStatus.ParameterName = "$watch_status"; cmd.Parameters.Add(pWatchStatus);
+            var pWe = cmd.CreateParameter(); pWe.ParameterName = "$we"; cmd.Parameters.Add(pWe);
+            var pTe = cmd.CreateParameter(); pTe.ParameterName = "$te"; cmd.Parameters.Add(pTe);
+            var pRating = cmd.CreateParameter(); pRating.ParameterName = "$rating"; cmd.Parameters.Add(pRating);
+            var pNow = cmd.CreateParameter(); pNow.ParameterName = "$now"; cmd.Parameters.Add(pNow);
+            pNow.Value = now;
+            pUser.Value = userId;
+
+            foreach (var s in shows)
+            {
+                pShow.Value = s.ShowId;
+                pTitle.Value = s.Title ?? string.Empty;
+                pTitleOrig.Value = (object)s.TitleOriginal ?? DBNull.Value;
+                pYear.Value = (object)s.Year ?? DBNull.Value;
+                pStatus.Value = (object)s.Status ?? DBNull.Value;
+                pWatchStatus.Value = (object)s.WatchStatus ?? DBNull.Value;
+                pWe.Value = s.WatchedEpisodes;
+                pTe.Value = s.TotalEpisodes;
+                pRating.Value = (object)s.Rating ?? DBNull.Value;
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            await tx.CommitAsync();
+        }
+
+        public async Task UpsertEpisodes(string userId, int showId, IReadOnlyList<JournalEpisode> episodes)
+        {
+            if (episodes.Count == 0) return;
+            var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            await using var conn = Open();
+            await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.Transaction = tx;
+            cmd.CommandText = @"
+INSERT INTO myshows_episodes (episode_id, jellyfin_user_id, show_id, season_number,
+                              episode_number, watch_date, rating, is_favorite, last_synced_at)
+VALUES ($eid, $user, $show, $season, $ep, $when, $rating, $fav, $now)
+ON CONFLICT(episode_id, jellyfin_user_id) DO UPDATE SET
+    show_id        = excluded.show_id,
+    season_number  = excluded.season_number,
+    episode_number = excluded.episode_number,
+    watch_date     = excluded.watch_date,
+    rating         = excluded.rating,
+    is_favorite    = excluded.is_favorite,
+    last_synced_at = excluded.last_synced_at;";
+
+            var pEid = cmd.CreateParameter(); pEid.ParameterName = "$eid"; cmd.Parameters.Add(pEid);
+            var pUser = cmd.CreateParameter(); pUser.ParameterName = "$user"; cmd.Parameters.Add(pUser);
+            var pShow = cmd.CreateParameter(); pShow.ParameterName = "$show"; cmd.Parameters.Add(pShow);
+            var pSeason = cmd.CreateParameter(); pSeason.ParameterName = "$season"; cmd.Parameters.Add(pSeason);
+            var pEp = cmd.CreateParameter(); pEp.ParameterName = "$ep"; cmd.Parameters.Add(pEp);
+            var pWhen = cmd.CreateParameter(); pWhen.ParameterName = "$when"; cmd.Parameters.Add(pWhen);
+            var pRating = cmd.CreateParameter(); pRating.ParameterName = "$rating"; cmd.Parameters.Add(pRating);
+            var pFav = cmd.CreateParameter(); pFav.ParameterName = "$fav"; cmd.Parameters.Add(pFav);
+            var pNow = cmd.CreateParameter(); pNow.ParameterName = "$now"; cmd.Parameters.Add(pNow);
+            pNow.Value = now;
+            pUser.Value = userId;
+            pShow.Value = showId;
+
+            foreach (var e in episodes)
+            {
+                pEid.Value = e.EpisodeId;
+                pSeason.Value = e.SeasonNumber;
+                pEp.Value = e.EpisodeNumber;
+                pWhen.Value = e.WatchDate.HasValue
+                    ? (object)e.WatchDate.Value.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture)
+                    : DBNull.Value;
+                pRating.Value = (object)e.Rating ?? DBNull.Value;
+                pFav.Value = e.IsFavorite ? 1 : 0;
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            await tx.CommitAsync();
+        }
+
+        public async Task UpsertMovies(string userId, IReadOnlyList<JournalMovie> movies)
+        {
+            if (movies.Count == 0) return;
+            var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            await using var conn = Open();
+            await using var tx = (SqliteTransaction)await conn.BeginTransactionAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.Transaction = tx;
+            cmd.CommandText = @"
+INSERT INTO myshows_movies (movie_id, jellyfin_user_id, tmdb_id, title, watch_status,
+                            watch_date, rating, last_synced_at)
+VALUES ($mid, $user, $tmdb, $title, $ws, $when, $rating, $now)
+ON CONFLICT(movie_id, jellyfin_user_id) DO UPDATE SET
+    tmdb_id        = excluded.tmdb_id,
+    title          = excluded.title,
+    watch_status   = excluded.watch_status,
+    watch_date     = excluded.watch_date,
+    rating         = excluded.rating,
+    last_synced_at = excluded.last_synced_at;";
+
+            var pMid = cmd.CreateParameter(); pMid.ParameterName = "$mid"; cmd.Parameters.Add(pMid);
+            var pUser = cmd.CreateParameter(); pUser.ParameterName = "$user"; cmd.Parameters.Add(pUser);
+            var pTmdb = cmd.CreateParameter(); pTmdb.ParameterName = "$tmdb"; cmd.Parameters.Add(pTmdb);
+            var pTitle = cmd.CreateParameter(); pTitle.ParameterName = "$title"; cmd.Parameters.Add(pTitle);
+            var pWs = cmd.CreateParameter(); pWs.ParameterName = "$ws"; cmd.Parameters.Add(pWs);
+            var pWhen = cmd.CreateParameter(); pWhen.ParameterName = "$when"; cmd.Parameters.Add(pWhen);
+            var pRating = cmd.CreateParameter(); pRating.ParameterName = "$rating"; cmd.Parameters.Add(pRating);
+            var pNow = cmd.CreateParameter(); pNow.ParameterName = "$now"; cmd.Parameters.Add(pNow);
+            pNow.Value = now;
+            pUser.Value = userId;
+
+            foreach (var m in movies)
+            {
+                pMid.Value = m.MovieId;
+                pTmdb.Value = (object)m.TmdbId ?? DBNull.Value;
+                pTitle.Value = (object)m.Title ?? DBNull.Value;
+                pWs.Value = (object)m.WatchStatus ?? DBNull.Value;
+                pWhen.Value = m.WatchDate.HasValue
+                    ? (object)m.WatchDate.Value.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture)
+                    : DBNull.Value;
+                pRating.Value = (object)m.Rating ?? DBNull.Value;
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            await tx.CommitAsync();
+        }
+
+        public async Task<HistoryStats> GetStats(string userId, int topShows = 10)
+        {
+            await using var conn = Open();
+
+            var stats = new HistoryStats { JellyfinUserId = userId };
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = @"
+SELECT
+    COUNT(*) AS shows_total,
+    SUM(CASE WHEN watch_status = 'finished' THEN 1 ELSE 0 END) AS shows_finished,
+    SUM(CASE WHEN watch_status = 'watching' THEN 1 ELSE 0 END) AS shows_watching,
+    COALESCE(SUM(watched_episodes), 0) AS eps_watched,
+    COALESCE(SUM(total_episodes), 0)   AS eps_aired,
+    COALESCE(MAX(last_synced_at), 0)   AS last_sync
+FROM myshows_shows
+WHERE jellyfin_user_id = $user;";
+                cmd.Parameters.AddWithValue("$user", userId);
+                await using var r = await cmd.ExecuteReaderAsync();
+                if (await r.ReadAsync())
+                {
+                    stats.ShowsTotal = r.GetInt32(0);
+                    stats.ShowsFinished = r.IsDBNull(1) ? 0 : r.GetInt32(1);
+                    stats.ShowsWatching = r.IsDBNull(2) ? 0 : r.GetInt32(2);
+                    stats.EpisodesWatched = r.GetInt32(3);
+                    stats.EpisodesAired = r.GetInt32(4);
+                    stats.LastSyncedAtUnix = r.GetInt64(5);
+                }
+            }
+
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = @"
+SELECT COUNT(*) FROM myshows_movies
+WHERE jellyfin_user_id = $user AND watch_status = 'finished';";
+                cmd.Parameters.AddWithValue("$user", userId);
+                stats.MoviesWatched = Convert.ToInt32(await cmd.ExecuteScalarAsync() ?? 0);
+            }
+
+            var top = new List<HistoryStatsTopShow>(topShows);
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = @"
+SELECT show_id, title, year, watched_episodes, total_episodes, watch_status
+FROM myshows_shows
+WHERE jellyfin_user_id = $user
+ORDER BY watched_episodes DESC, title ASC
+LIMIT $limit;";
+                cmd.Parameters.AddWithValue("$user", userId);
+                cmd.Parameters.AddWithValue("$limit", topShows);
+                await using var r = await cmd.ExecuteReaderAsync();
+                while (await r.ReadAsync())
+                {
+                    top.Add(new HistoryStatsTopShow
+                    {
+                        ShowId = r.GetInt32(0),
+                        Title = r.GetString(1),
+                        Year = r.IsDBNull(2) ? (int?)null : r.GetInt32(2),
+                        WatchedEpisodes = r.GetInt32(3),
+                        TotalEpisodes = r.GetInt32(4),
+                        WatchStatus = r.IsDBNull(5) ? null : r.GetString(5),
+                    });
+                }
+            }
+            stats.TopShows = top;
+            return stats;
+        }
+
+        public async Task<IReadOnlyDictionary<(int Season, int Episode), DateTimeOffset?>> GetWatchedEpisodesForShow(string userId, int showId)
+        {
+            var result = new Dictionary<(int, int), DateTimeOffset?>();
+            await using var conn = Open();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+SELECT season_number, episode_number, watch_date
+FROM myshows_episodes
+WHERE jellyfin_user_id = $user AND show_id = $show;";
+            cmd.Parameters.AddWithValue("$user", userId);
+            cmd.Parameters.AddWithValue("$show", showId);
+            await using var r = await cmd.ExecuteReaderAsync();
+            while (await r.ReadAsync())
+            {
+                var key = (r.GetInt32(0), r.GetInt32(1));
+                DateTimeOffset? when = null;
+                if (!r.IsDBNull(2)
+                    && DateTimeOffset.TryParse(r.GetString(2), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var dt))
+                {
+                    when = dt;
+                }
+                result[key] = when;
+            }
+            return result;
+        }
+
+        public async Task<IReadOnlyList<RecentEpisode>> GetRecentEpisodes(string userId, int limit)
+        {
+            var result = new List<RecentEpisode>(limit);
+            await using var conn = Open();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+SELECT e.show_id, s.title, e.season_number, e.episode_number, e.watch_date
+FROM myshows_episodes e
+LEFT JOIN myshows_shows s
+       ON s.show_id = e.show_id AND s.jellyfin_user_id = e.jellyfin_user_id
+WHERE e.jellyfin_user_id = $user AND e.watch_date IS NOT NULL
+ORDER BY e.watch_date DESC
+LIMIT $limit;";
+            cmd.Parameters.AddWithValue("$user", userId);
+            cmd.Parameters.AddWithValue("$limit", limit);
+            await using var r = await cmd.ExecuteReaderAsync();
+            while (await r.ReadAsync())
+            {
+                result.Add(new RecentEpisode
+                {
+                    ShowId = r.GetInt32(0),
+                    ShowTitle = r.IsDBNull(1) ? "?" : r.GetString(1),
+                    SeasonNumber = r.GetInt32(2),
+                    EpisodeNumber = r.GetInt32(3),
+                    WatchDate = r.IsDBNull(4) ? null : r.GetString(4),
+                });
+            }
+            return result;
+        }
+
+        private SqliteConnection Open()
+        {
+            var conn = new SqliteConnection(_connectionString);
+            conn.Open();
+            return conn;
+        }
+    }
+}

--- a/MyShows/MyShows.csproj
+++ b/MyShows/MyShows.csproj
@@ -7,8 +7,8 @@
     <Product>MyShows Jellyfin Plugin</Product>
     <Description></Description>
     <PackageProjectUrl></PackageProjectUrl>
-    <AssemblyVersion>5.4.1.0</AssemblyVersion>
-    <FileVersion>5.4.1.0</FileVersion>
+    <AssemblyVersion>5.4.2.0</AssemblyVersion>
+    <FileVersion>5.4.2.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/MyShows/MyShows.csproj
+++ b/MyShows/MyShows.csproj
@@ -7,8 +7,8 @@
     <Product>MyShows Jellyfin Plugin</Product>
     <Description></Description>
     <PackageProjectUrl></PackageProjectUrl>
-    <AssemblyVersion>5.3.0.0</AssemblyVersion>
-    <FileVersion>5.3.0.0</FileVersion>
+    <AssemblyVersion>5.4.0.0</AssemblyVersion>
+    <FileVersion>5.4.0.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -30,6 +30,7 @@
     <PackageReference Include="Jellyfin.Model" Version="10.11.11" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.11" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/MyShows/MyShows.csproj
+++ b/MyShows/MyShows.csproj
@@ -7,8 +7,8 @@
     <Product>MyShows Jellyfin Plugin</Product>
     <Description></Description>
     <PackageProjectUrl></PackageProjectUrl>
-    <AssemblyVersion>5.1.0.0</AssemblyVersion>
-    <FileVersion>5.1.0.0</FileVersion>
+    <AssemblyVersion>5.2.0.0</AssemblyVersion>
+    <FileVersion>5.2.0.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/MyShows/MyShows.csproj
+++ b/MyShows/MyShows.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Authors>Denis Shemanaev</Authors>
     <PackageId>MyShows Jellyfin Plugin</PackageId>
     <Product>MyShows Jellyfin Plugin</Product>
     <Description></Description>
     <PackageProjectUrl></PackageProjectUrl>
-    <AssemblyVersion>5.2.0.0</AssemblyVersion>
-    <FileVersion>5.2.0.0</FileVersion>
+    <AssemblyVersion>5.3.0.0</AssemblyVersion>
+    <FileVersion>5.3.0.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -26,10 +26,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.9.0" />
-    <PackageReference Include="Jellyfin.Model" Version="10.9.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.11" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.11" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.11" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/MyShows/MyShows.csproj
+++ b/MyShows/MyShows.csproj
@@ -7,8 +7,8 @@
     <Product>MyShows Jellyfin Plugin</Product>
     <Description></Description>
     <PackageProjectUrl></PackageProjectUrl>
-    <AssemblyVersion>5.4.0.1</AssemblyVersion>
-    <FileVersion>5.4.0.1</FileVersion>
+    <AssemblyVersion>5.4.1.0</AssemblyVersion>
+    <FileVersion>5.4.1.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/MyShows/MyShows.csproj
+++ b/MyShows/MyShows.csproj
@@ -7,8 +7,8 @@
     <Product>MyShows Jellyfin Plugin</Product>
     <Description></Description>
     <PackageProjectUrl></PackageProjectUrl>
-    <AssemblyVersion>5.4.0.0</AssemblyVersion>
-    <FileVersion>5.4.0.0</FileVersion>
+    <AssemblyVersion>5.4.0.1</AssemblyVersion>
+    <FileVersion>5.4.0.1</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/MyShows/MyShowsApi/Api20/ApiConstants.cs
+++ b/MyShows/MyShowsApi/Api20/ApiConstants.cs
@@ -4,13 +4,13 @@ namespace MyShows.MyShowsApi.Api20
     internal class ApiConstants
     {
 #if LOCAL_SERVER
-        public const string RpcUri = "https://api.myshows.me/v2/rpc/";
+        public const string RpcUri = "https://myshows.me/v3/rpc/";
         public const string OauthAuthorizeUri = "http://localhost:3000/dialog/authorize";
         public const string OauthTokenUri = "http://localhost:3000/oauth/token";
         public const string ClientId = "abc123";
         public const string ClientSecret = "ssh-secret";
 #else
-        public const string RpcUri = "https://api.myshows.me/v2/rpc/";
+        public const string RpcUri = "https://myshows.me/v3/rpc/";
         public const string OauthAuthorizeUri = "https://myshows.me/oauth/authorize";
         public const string OauthTokenUri = "https://myshows.me/oauth/token";
 

--- a/MyShows/MyShowsApi/Api20/Dto.cs
+++ b/MyShows/MyShowsApi/Api20/Dto.cs
@@ -98,7 +98,18 @@ namespace MyShows.MyShowsApi.Api20
 
     public class MovieStatus
     {
-        public int movieId { get; set; }
+        public int id { get; set; }
         public string watchStatus { get; set; }
+    }
+
+    public class ProfileEpisodesArgs
+    {
+        public int showId { get; set; }
+    }
+
+    public class ProfileEpisode
+    {
+        public int id { get; set; }
+        public string watchDate { get; set; }
     }
 }

--- a/MyShows/MyShowsApi/Api20/Dto.cs
+++ b/MyShows/MyShowsApi/Api20/Dto.cs
@@ -78,4 +78,32 @@ namespace MyShows.MyShowsApi.Api20
         public int showId { get; set; }
         public string watchStatus { get; set; }
     }
+
+    public class MoviesAddExternalMovieArgs
+    {
+        public string externalId { get; set; }
+        public string source { get; set; }
+    }
+
+    public class ManageSetMovieStatusArgs
+    {
+        public int id { get; set; }
+        public string status { get; set; }
+    }
+
+    public class ManageMovieArgs
+    {
+        public int id { get; set; }
+    }
+
+    public class ProfileMovieStatusesArgs
+    {
+        public int[] movieIds { get; set; }
+    }
+
+    public class MovieStatus
+    {
+        public int movieId { get; set; }
+        public string watchStatus { get; set; }
+    }
 }

--- a/MyShows/MyShowsApi/Api20/Dto.cs
+++ b/MyShows/MyShowsApi/Api20/Dto.cs
@@ -111,5 +111,26 @@ namespace MyShows.MyShowsApi.Api20
     {
         public int id { get; set; }
         public string watchDate { get; set; }
+        public double? rating { get; set; }
+        public bool isFavorite { get; set; }
+    }
+
+    public class ProfileShowSummary
+    {
+        public ProfileShowSummaryInner show { get; set; }
+        public string watchStatus { get; set; }
+        public double? rating { get; set; }
+        public int watchCount { get; set; }
+        public int totalEpisodes { get; set; }
+        public int watchedEpisodes { get; set; }
+    }
+
+    public class ProfileShowSummaryInner
+    {
+        public int id { get; set; }
+        public string title { get; set; }
+        public string titleOriginal { get; set; }
+        public string status { get; set; }
+        public int? year { get; set; }
     }
 }

--- a/MyShows/MyShowsApi/Api20/Dto.cs
+++ b/MyShows/MyShowsApi/Api20/Dto.cs
@@ -87,13 +87,8 @@ namespace MyShows.MyShowsApi.Api20
 
     public class ManageSetMovieStatusArgs
     {
-        public int id { get; set; }
+        public int movieId { get; set; }
         public string status { get; set; }
-    }
-
-    public class ManageMovieArgs
-    {
-        public int id { get; set; }
     }
 
     public class ProfileMovieStatusesArgs

--- a/MyShows/MyShowsApi/Api20/Dto.cs
+++ b/MyShows/MyShowsApi/Api20/Dto.cs
@@ -132,5 +132,6 @@ namespace MyShows.MyShowsApi.Api20
         public string titleOriginal { get; set; }
         public string status { get; set; }
         public int? year { get; set; }
+        public int? totalSeasons { get; set; }
     }
 }

--- a/MyShows/MyShowsApi/Api20/MyShowsApi20.cs
+++ b/MyShows/MyShowsApi/Api20/MyShowsApi20.cs
@@ -223,9 +223,14 @@ namespace MyShows.MyShowsApi.Api20
                 method = method,
                 @params = args,
             };
-            var httpClient = GetHttpClient(user.AccessToken);
-            var content = new StringContent(JsonSerializer.Serialize(call, JsonDefaults.Options), Encoding.UTF8, "application/json");
-            var response = await httpClient.PostAsync(ApiConstants.RpcUri, content);
+            var httpClient = GetHttpClient();
+            var request = new HttpRequestMessage(HttpMethod.Post, ApiConstants.RpcUri)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(call, JsonDefaults.Options), Encoding.UTF8, "application/json"),
+            };
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            request.Headers.TryAddWithoutValidation("Authorization2", "Bearer " + user.AccessToken);
+            var response = await httpClient.SendAsync(request);
 
             var result = await Extensions.DeserializeFromHttp<JsonRpcResult<T>>(response);
             if (result.error != null)

--- a/MyShows/MyShowsApi/Api20/MyShowsApi20.cs
+++ b/MyShows/MyShowsApi/Api20/MyShowsApi20.cs
@@ -172,8 +172,8 @@ namespace MyShows.MyShowsApi.Api20
 
             var success = await Execute<bool>(user, "manage.SetMovieStatus", new ManageSetMovieStatusArgs
             {
-                id = movieId,
-                status = check ? "watched" : "remove"
+                movieId = movieId,
+                status = check ? "finished" : "remove"
             });
             return success;
         }

--- a/MyShows/MyShowsApi/Api20/MyShowsApi20.cs
+++ b/MyShows/MyShowsApi/Api20/MyShowsApi20.cs
@@ -152,6 +152,7 @@ namespace MyShows.MyShowsApi.Api20
             });
 
             _showsCache.Store(cacheKey, show, CACHED_SHOW_STORAGE_INTERVAL);
+            _showsCache.Store("internal:" + show.id, show, CACHED_SHOW_STORAGE_INTERVAL);
 
             return show;
         }
@@ -208,35 +209,10 @@ namespace MyShows.MyShowsApi.Api20
             return movieId;
         }
 
-        public async Task<IReadOnlyDictionary<(int Season, int Episode), DateTimeOffset?>> GetWatchedEpisodes(UserConfig user, Series series)
+        public async Task<int> ResolveMyShowsShowId(UserConfig user, Series series)
         {
             var show = await GetShow(user, series);
-            if (show == default(ShowSummary) || show.episodes == null) return new Dictionary<(int, int), DateTimeOffset?>();
-
-            var byId = show.episodes
-                .GroupBy(e => e.id)
-                .ToDictionary(g => g.Key, g => g.First());
-
-            var profileEpisodes = await Execute<ProfileEpisode[]>(user, "profile.Episodes", new ProfileEpisodesArgs
-            {
-                showId = show.id,
-            });
-            if (profileEpisodes == null) return new Dictionary<(int, int), DateTimeOffset?>();
-
-            var result = new Dictionary<(int Season, int Episode), DateTimeOffset?>();
-            foreach (var pe in profileEpisodes)
-            {
-                if (!byId.TryGetValue(pe.id, out var summary)) continue;
-                var key = (summary.seasonNumber, summary.episodeNumber);
-                DateTimeOffset? when = null;
-                if (!string.IsNullOrEmpty(pe.watchDate)
-                    && DateTimeOffset.TryParse(pe.watchDate, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsed))
-                {
-                    when = parsed;
-                }
-                result[key] = when;
-            }
-            return result;
+            return show?.id ?? 0;
         }
 
         public async Task<IReadOnlyDictionary<Guid, bool>> GetWatchedMovies(UserConfig user, IReadOnlyList<Movie> movies)
@@ -265,6 +241,51 @@ namespace MyShows.MyShowsApi.Api20
                 result[jellyfinId] = string.Equals(status.watchStatus, "finished", StringComparison.OrdinalIgnoreCase);
             }
             return result;
+        }
+
+        public async Task<IReadOnlyList<ProfileShowSummary>> GetProfileShows(UserConfig user)
+        {
+            var shows = await Execute<ProfileShowSummary[]>(user, "profile.Shows", new { });
+            return shows ?? Array.Empty<ProfileShowSummary>();
+        }
+
+        public async Task<IReadOnlyList<ProfileEpisode>> GetEpisodesByShowId(UserConfig user, int showId)
+        {
+            var episodes = await Execute<ProfileEpisode[]>(user, "profile.Episodes", new ProfileEpisodesArgs
+            {
+                showId = showId,
+            });
+            return episodes ?? Array.Empty<ProfileEpisode>();
+        }
+
+        public Task<int> GetMyShowsMovieId(UserConfig user, Movie movie) => GetMovieId(user, movie);
+
+        public async Task<IReadOnlyList<MovieStatus>> GetMovieStatusesByIds(UserConfig user, IReadOnlyList<int> movieIds)
+        {
+            if (movieIds == null || movieIds.Count == 0) return Array.Empty<MovieStatus>();
+            var statuses = await Execute<MovieStatus[]>(user, "profile.MovieStatuses", new ProfileMovieStatusesArgs
+            {
+                movieIds = movieIds.ToArray(),
+            });
+            return statuses ?? Array.Empty<MovieStatus>();
+        }
+
+        public async Task<ShowSummary> GetShowWithEpisodesById(UserConfig user, int showId)
+        {
+            var cacheKey = "internal:" + showId;
+            var cached = _showsCache.Get(cacheKey);
+            if (cached != default(ShowSummary)) return cached;
+
+            var show = await Execute<ShowSummary>(user, "shows.GetById", new ShowsGetByIdArgs
+            {
+                showId = showId,
+                withEpisodes = true,
+            });
+            if (show != default(ShowSummary))
+            {
+                _showsCache.Store(cacheKey, show, CACHED_SHOW_STORAGE_INTERVAL);
+            }
+            return show;
         }
 
         private async Task<T> Execute<T>(UserConfig user, string method, object args)

--- a/MyShows/MyShowsApi/Api20/MyShowsApi20.cs
+++ b/MyShows/MyShowsApi/Api20/MyShowsApi20.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -205,6 +206,65 @@ namespace MyShows.MyShowsApi.Api20
 
             _moviesCache.Store(cacheKey, movieId, CACHED_MOVIE_STORAGE_INTERVAL);
             return movieId;
+        }
+
+        public async Task<IReadOnlyDictionary<(int Season, int Episode), DateTimeOffset?>> GetWatchedEpisodes(UserConfig user, Series series)
+        {
+            var show = await GetShow(user, series);
+            if (show == default(ShowSummary) || show.episodes == null) return new Dictionary<(int, int), DateTimeOffset?>();
+
+            var byId = show.episodes
+                .GroupBy(e => e.id)
+                .ToDictionary(g => g.Key, g => g.First());
+
+            var profileEpisodes = await Execute<ProfileEpisode[]>(user, "profile.Episodes", new ProfileEpisodesArgs
+            {
+                showId = show.id,
+            });
+            if (profileEpisodes == null) return new Dictionary<(int, int), DateTimeOffset?>();
+
+            var result = new Dictionary<(int Season, int Episode), DateTimeOffset?>();
+            foreach (var pe in profileEpisodes)
+            {
+                if (!byId.TryGetValue(pe.id, out var summary)) continue;
+                var key = (summary.seasonNumber, summary.episodeNumber);
+                DateTimeOffset? when = null;
+                if (!string.IsNullOrEmpty(pe.watchDate)
+                    && DateTimeOffset.TryParse(pe.watchDate, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsed))
+                {
+                    when = parsed;
+                }
+                result[key] = when;
+            }
+            return result;
+        }
+
+        public async Task<IReadOnlyDictionary<Guid, bool>> GetWatchedMovies(UserConfig user, IReadOnlyList<Movie> movies)
+        {
+            if (movies == null || movies.Count == 0) return new Dictionary<Guid, bool>();
+
+            var myShowsToJellyfin = new Dictionary<int, Guid>();
+            foreach (var movie in movies)
+            {
+                var myShowsMovieId = await GetMovieId(user, movie);
+                if (myShowsMovieId <= 0) continue;
+                myShowsToJellyfin[myShowsMovieId] = movie.Id;
+            }
+            if (myShowsToJellyfin.Count == 0) return new Dictionary<Guid, bool>();
+
+            var statuses = await Execute<MovieStatus[]>(user, "profile.MovieStatuses", new ProfileMovieStatusesArgs
+            {
+                movieIds = myShowsToJellyfin.Keys.ToArray(),
+            });
+
+            var result = new Dictionary<Guid, bool>();
+            if (statuses == null) return result;
+            foreach (var status in statuses)
+            {
+                if (!myShowsToJellyfin.TryGetValue(status.id, out var jellyfinId)) continue;
+                result[jellyfinId] = string.Equals(status.watchStatus, "finished", StringComparison.OrdinalIgnoreCase);
+            }
+            return result;
         }
 
         private async Task<T> Execute<T>(UserConfig user, string method, object args)

--- a/MyShows/MyShowsApi/Api20/MyShowsApi20.cs
+++ b/MyShows/MyShowsApi/Api20/MyShowsApi20.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Jellyfin.Extensions.Json;
 using MediaBrowser.Common.Net;
+using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using Microsoft.Extensions.Logging;
 using MyShows.Configuration;
@@ -22,6 +23,8 @@ namespace MyShows.MyShowsApi.Api20
         private static readonly TimeSpan CACHED_SHOW_STORAGE_INTERVAL = TimeSpan.FromHours(24);
         private readonly ExpireableCache<string, ShowSummary> _showsCache = new();
         private readonly List<Guid> _lastWatchedShows = new();
+        private readonly ExpireableCache<string, int> _moviesCache = new();
+        private static readonly TimeSpan CACHED_MOVIE_STORAGE_INTERVAL = TimeSpan.FromHours(24);
 
         public MyShowsApi20(
             ILogger logger,
@@ -150,6 +153,58 @@ namespace MyShows.MyShowsApi.Api20
             _showsCache.Store(cacheKey, show, CACHED_SHOW_STORAGE_INTERVAL);
 
             return show;
+        }
+
+        public async Task<bool> CheckMovie(UserConfig user, Movie item)
+        {
+            return await ToggleMovie(user, item, true);
+        }
+
+        public async Task<bool> UnCheckMovie(UserConfig user, Movie item)
+        {
+            return await ToggleMovie(user, item, false);
+        }
+
+        private async Task<bool> ToggleMovie(UserConfig user, Movie item, bool check)
+        {
+            var movieId = await GetMovieId(user, item);
+            if (movieId <= 0) return false;
+
+            var success = await Execute<bool>(user, "manage.SetMovieStatus", new ManageSetMovieStatusArgs
+            {
+                id = movieId,
+                status = check ? "watched" : "remove"
+            });
+            return success;
+        }
+
+        protected async Task<int> GetMovieId(UserConfig user, Movie item)
+        {
+            var tmdbId = item.GetTmdbId();
+            if (string.IsNullOrEmpty(tmdbId))
+            {
+                _logger.LogWarning("No TMDb id for movie '{0}' — MyShows only matches movies by TMDb id", item.Name);
+                return 0;
+            }
+
+            var cacheKey = "tmdb:" + tmdbId;
+            var cached = _moviesCache.Get(cacheKey);
+            if (cached > 0) return cached;
+
+            var movieId = await Execute<int>(user, "movies.AddExternalMovie", new MoviesAddExternalMovieArgs
+            {
+                externalId = tmdbId,
+                source = "tmdb"
+            });
+
+            if (movieId <= 0)
+            {
+                _logger.LogWarning("MyShows did not return an id for TMDb={0} ('{1}')", tmdbId, item.Name);
+                return 0;
+            }
+
+            _moviesCache.Store(cacheKey, movieId, CACHED_MOVIE_STORAGE_INTERVAL);
+            return movieId;
         }
 
         private async Task<T> Execute<T>(UserConfig user, string method, object args)

--- a/MyShows/MyShowsApi/Api20/MyShowsApi20.cs
+++ b/MyShows/MyShowsApi/Api20/MyShowsApi20.cs
@@ -182,26 +182,26 @@ namespace MyShows.MyShowsApi.Api20
 
         protected async Task<int> GetMovieId(UserConfig user, Movie item)
         {
-            var tmdbId = item.GetTmdbId();
-            if (string.IsNullOrEmpty(tmdbId))
+            var (externalId, source) = item.GetBestMovieExternalId();
+            if (string.IsNullOrEmpty(externalId))
             {
-                _logger.LogWarning("No TMDb id for movie '{0}' — MyShows only matches movies by TMDb id", item.Name);
+                _logger.LogWarning("No TMDb/KinoPoisk id for movie '{0}' — MyShows cannot match it", item.Name);
                 return 0;
             }
 
-            var cacheKey = "tmdb:" + tmdbId;
+            var cacheKey = source + ":" + externalId;
             var cached = _moviesCache.Get(cacheKey);
             if (cached > 0) return cached;
 
             var movieId = await Execute<int>(user, "movies.AddExternalMovie", new MoviesAddExternalMovieArgs
             {
-                externalId = tmdbId,
-                source = "tmdb"
+                externalId = externalId,
+                source = source
             });
 
             if (movieId <= 0)
             {
-                _logger.LogWarning("MyShows did not return an id for TMDb={0} ('{1}')", tmdbId, item.Name);
+                _logger.LogWarning("MyShows did not return an id for {0}={1} ('{2}')", source, externalId, item.Name);
                 return 0;
             }
 

--- a/MyShows/MyShowsApi/IMyShowsApi.cs
+++ b/MyShows/MyShowsApi/IMyShowsApi.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MyShows.Configuration;
 
@@ -11,5 +12,8 @@ namespace MyShows.MyShowsApi
         Task<bool> CheckEpisode(UserConfig user, Episode item);
         Task<bool> UnCheckEpisode(UserConfig user, Episode item);
         Task<bool> SyncEpisodes(UserConfig user, List<Episode> seen, List<Episode> unseen);
+
+        Task<bool> CheckMovie(UserConfig user, Movie item);
+        Task<bool> UnCheckMovie(UserConfig user, Movie item);
     }
 }

--- a/MyShows/MyShowsApi/IMyShowsApi.cs
+++ b/MyShows/MyShowsApi/IMyShowsApi.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MyShows.Configuration;
+using MyShows.MyShowsApi.Api20;
 
 namespace MyShows.MyShowsApi
 {
@@ -17,7 +18,12 @@ namespace MyShows.MyShowsApi
         Task<bool> CheckMovie(UserConfig user, Movie item);
         Task<bool> UnCheckMovie(UserConfig user, Movie item);
 
-        Task<IReadOnlyDictionary<(int Season, int Episode), DateTimeOffset?>> GetWatchedEpisodes(UserConfig user, Series series);
-        Task<IReadOnlyDictionary<Guid, bool>> GetWatchedMovies(UserConfig user, IReadOnlyList<Movie> movies);
+        Task<int> ResolveMyShowsShowId(UserConfig user, Series series);
+
+        Task<IReadOnlyList<ProfileShowSummary>> GetProfileShows(UserConfig user);
+        Task<IReadOnlyList<ProfileEpisode>> GetEpisodesByShowId(UserConfig user, int showId);
+        Task<ShowSummary> GetShowWithEpisodesById(UserConfig user, int showId);
+        Task<int> GetMyShowsMovieId(UserConfig user, Movie movie);
+        Task<IReadOnlyList<MovieStatus>> GetMovieStatusesByIds(UserConfig user, IReadOnlyList<int> movieIds);
     }
 }

--- a/MyShows/MyShowsApi/IMyShowsApi.cs
+++ b/MyShows/MyShowsApi/IMyShowsApi.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities.Movies;
@@ -15,5 +16,8 @@ namespace MyShows.MyShowsApi
 
         Task<bool> CheckMovie(UserConfig user, Movie item);
         Task<bool> UnCheckMovie(UserConfig user, Movie item);
+
+        Task<IReadOnlyDictionary<(int Season, int Episode), DateTimeOffset?>> GetWatchedEpisodes(UserConfig user, Series series);
+        Task<IReadOnlyDictionary<Guid, bool>> GetWatchedMovies(UserConfig user, IReadOnlyList<Movie> movies);
     }
 }

--- a/MyShows/ScrobbleSuppressor.cs
+++ b/MyShows/ScrobbleSuppressor.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace MyShows
+{
+    internal static class ScrobbleSuppressor
+    {
+        private static readonly ConcurrentDictionary<(Guid UserId, Guid ItemId), DateTime> _suppressed = new();
+        private static readonly TimeSpan TtlOnMiss = TimeSpan.FromSeconds(30);
+        private const int SweepEveryN = 64;
+        private static int _suppressCount;
+
+        public static void Suppress(Guid userId, Guid itemId)
+        {
+            _suppressed[(userId, itemId)] = DateTime.UtcNow.Add(TtlOnMiss);
+            if (Interlocked.Increment(ref _suppressCount) % SweepEveryN == 0)
+            {
+                SweepExpired();
+            }
+        }
+
+        public static bool TryConsume(Guid userId, Guid itemId)
+        {
+            if (!_suppressed.TryRemove((userId, itemId), out var expiresAt)) return false;
+            if (DateTime.UtcNow > expiresAt) return false;
+            return true;
+        }
+
+        private static void SweepExpired()
+        {
+            var now = DateTime.UtcNow;
+            foreach (var kvp in _suppressed)
+            {
+                if (kvp.Value < now)
+                {
+                    _suppressed.TryRemove(kvp);
+                }
+            }
+        }
+    }
+}

--- a/MyShows/Scrobbler.cs
+++ b/MyShows/Scrobbler.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
@@ -79,17 +80,30 @@ namespace MyShows
             float percentageWatched = (float)e.Session.PlayState.PositionTicks / (float)e.Session.NowPlayingItem.RunTimeTicks * 100f;
             if (percentageWatched < user.ScrobbleAt) return;
 
-            if (e.Item is not Episode episode) return;
-            if (_lastScrobbled.Contains(episode.Id)) return;
+            if (_lastScrobbled.Contains(e.Item.Id)) return;
 
             try
             {
                 _logger.LogInformation("Item is played 90%. Scrobble");
 
-                var result = await _client.GetApi(user.ApiVersion).CheckEpisode(user, episode);
-                _logger.LogInformation("Checked episode '{0}' S{1}E{2} {3}", episode.Series.Name,
-                    episode.Season.IndexNumber, episode.IndexNumber, result ? "successfully" : "failed");
-                if (result) _lastScrobbled.Add(episode.Id);
+                switch (e.Item)
+                {
+                    case Episode episode:
+                    {
+                        var result = await _client.GetApi(user.ApiVersion).CheckEpisode(user, episode);
+                        _logger.LogInformation("Checked episode '{0}' S{1}E{2} {3}", episode.Series.Name,
+                            episode.Season.IndexNumber, episode.IndexNumber, result ? "successfully" : "failed");
+                        if (result) _lastScrobbled.Add(episode.Id);
+                        break;
+                    }
+                    case Movie movie:
+                    {
+                        var result = await _client.GetApi(user.ApiVersion).CheckMovie(user, movie);
+                        _logger.LogInformation("Checked movie '{0}' {1}", movie.Name, result ? "successfully" : "failed");
+                        if (result) _lastScrobbled.Add(movie.Id);
+                        break;
+                    }
+                }
             }
             catch (Exception ex)
             {
@@ -115,6 +129,24 @@ namespace MyShows
                 return;
             }
 
+            if (e.Item is Movie movie)
+            {
+                try
+                {
+                    var api = _client.GetApi(user.ApiVersion);
+                    var result = e.UserData.Played
+                        ? await api.CheckMovie(user, movie)
+                        : await api.UnCheckMovie(user, movie);
+                    _logger.LogInformation("Toggled movie '{0}' played={1} {2}",
+                        movie.Name, e.UserData.Played, result ? "successfully" : "failed");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error syncing movie watch state");
+                }
+                return;
+            }
+
             await _userDataHelper.AddEvent(user, e);
         }
 
@@ -126,9 +158,11 @@ namespace MyShows
 
             try
             {
-                if (e.Item is not Episode episode) return;
-                var result = await _client.GetApi(user.ApiVersion).SetShowStatusToWatching(user, episode.Series);
-                _logger.LogDebug("Started watching show '{0}' {1}", episode.Series.Name, result ? "successfully" : "failed");
+                if (e.Item is Episode episode)
+                {
+                    var result = await _client.GetApi(user.ApiVersion).SetShowStatusToWatching(user, episode.Series);
+                    _logger.LogDebug("Started watching show '{0}' {1}", episode.Series.Name, result ? "successfully" : "failed");
+                }
             }
             catch (Exception ex)
             {
@@ -145,17 +179,30 @@ namespace MyShows
 
             if (!e.PlayedToCompletion) return;
 
-            if (e.Item is not Episode episode) return;
-            if (_lastScrobbled.Contains(episode.Id)) return;
+            if (_lastScrobbled.Contains(e.Item.Id)) return;
 
             try
             {
                 _logger.LogInformation("Item is played. Scrobble");
 
-                var result = await _client.GetApi(user.ApiVersion).CheckEpisode(user, episode);
-                _logger.LogInformation("Checked episode '{0}' S{1}E{2} {3}", episode.Series.Name,
-                    episode.Season.IndexNumber, episode.IndexNumber, result ? "successfully" : "failed");
-                if (result) _lastScrobbled.Add(episode.Id);
+                switch (e.Item)
+                {
+                    case Episode episode:
+                    {
+                        var result = await _client.GetApi(user.ApiVersion).CheckEpisode(user, episode);
+                        _logger.LogInformation("Checked episode '{0}' S{1}E{2} {3}", episode.Series.Name,
+                            episode.Season.IndexNumber, episode.IndexNumber, result ? "successfully" : "failed");
+                        if (result) _lastScrobbled.Add(episode.Id);
+                        break;
+                    }
+                    case Movie movie:
+                    {
+                        var result = await _client.GetApi(user.ApiVersion).CheckMovie(user, movie);
+                        _logger.LogInformation("Checked movie '{0}' {1}", movie.Name, result ? "successfully" : "failed");
+                        if (result) _lastScrobbled.Add(movie.Id);
+                        break;
+                    }
+                }
             }
             catch (Exception ex)
             {
@@ -199,6 +246,11 @@ namespace MyShows
             {
                 var (_, source) = episode.Series.GetBestProviderId();
                 return source != null;
+            }
+
+            if (item is Movie movie)
+            {
+                return !string.IsNullOrEmpty(movie.GetTmdbId());
             }
 
             return false;

--- a/MyShows/Scrobbler.cs
+++ b/MyShows/Scrobbler.cs
@@ -121,6 +121,12 @@ namespace MyShows
 
             if (e.Item == null) return;
 
+            if (ScrobbleSuppressor.TryConsume(e.UserId, e.Item.Id))
+            {
+                _logger.LogDebug("Suppressed echo scrobble for item {0} (mark came from pull-task)", e.Item.Name);
+                return;
+            }
+
             var user = Plugin.Instance.Configuration.GetUserById(e.UserId);
 
             // Can't progress

--- a/MyShows/Scrobbler.cs
+++ b/MyShows/Scrobbler.cs
@@ -256,7 +256,8 @@ namespace MyShows
 
             if (item is Movie movie)
             {
-                return !string.IsNullOrEmpty(movie.GetTmdbId());
+                var (id, _) = movie.GetBestMovieExternalId();
+                return !string.IsNullOrEmpty(id);
             }
 
             return false;

--- a/MyShows/Tasks/PullWatchedFromMyShowsTask.cs
+++ b/MyShows/Tasks/PullWatchedFromMyShowsTask.cs
@@ -269,9 +269,13 @@ namespace MyShows.Tasks
                 IncludeItemTypes = new[] { BaseItemKind.Movie },
                 Recursive = true,
                 IsVirtualItem = false,
-            }).OfType<Movie>().Where(m => !string.IsNullOrEmpty(m.GetTmdbId())).ToList();
+            }).OfType<Movie>().Where(m =>
+            {
+                var (id, _) = m.GetBestMovieExternalId();
+                return !string.IsNullOrEmpty(id);
+            }).ToList();
 
-            _logger.LogInformation("Found {0} movies with TMDb id for {1}", movies.Count, user.Username);
+            _logger.LogInformation("Found {0} movies with TMDb/KP id for {1}", movies.Count, user.Username);
             if (movies.Count == 0)
             {
                 progress?.Report(slotStart + slotSize);

--- a/MyShows/Tasks/PullWatchedFromMyShowsTask.cs
+++ b/MyShows/Tasks/PullWatchedFromMyShowsTask.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -12,7 +14,9 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
 using MyShows.Configuration;
+using MyShows.Journal;
 using MyShows.MyShowsApi;
+using MyShows.MyShowsApi.Api20;
 
 namespace MyShows.Tasks
 {
@@ -90,16 +94,117 @@ namespace MyShows.Tasks
 
             _logger.LogInformation("Pulling watched state for user {0}", jellyfinUser.Username);
             var api = _apiFactory.GetApi(uc.ApiVersion);
+            var journal = OpenJournal();
 
             var userOffset = (double)userIndex / userCount * 100.0;
             var userSlot = 100.0 / userCount;
 
-            await PullEpisodes(api, uc, jellyfinUser, progress, userOffset, userSlot * 0.7, ct);
-            await PullMovies(api, uc, jellyfinUser, progress, userOffset + userSlot * 0.7, userSlot * 0.3, ct);
+            await SyncJournal(api, uc, journal, progress, userOffset, userSlot * 0.5, ct);
+            await PullEpisodes(api, uc, jellyfinUser, journal, progress, userOffset + userSlot * 0.5, userSlot * 0.35, ct);
+            await PullMovies(api, uc, jellyfinUser, journal, progress, userOffset + userSlot * 0.85, userSlot * 0.15, ct);
+        }
+
+        private JournalStore OpenJournal() => JournalAccessor.Open();
+
+        private async Task SyncJournal(IMyShowsApi api, UserConfig uc, JournalStore journal,
+            IProgress<double> progress, double slotStart, double slotSize, CancellationToken ct)
+        {
+            IReadOnlyList<ProfileShowSummary> profileShows;
+            try
+            {
+                profileShows = await api.GetProfileShows(uc);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Journal: failed to fetch profile.Shows for {0}", uc.Name);
+                progress?.Report(slotStart + slotSize);
+                return;
+            }
+
+            var journalShows = profileShows
+                .Where(s => s.show != null)
+                .Select(s => new JournalShow
+                {
+                    ShowId = s.show.id,
+                    Title = s.show.title,
+                    TitleOriginal = s.show.titleOriginal,
+                    Year = s.show.year,
+                    Status = s.show.status,
+                    WatchStatus = s.watchStatus,
+                    WatchedEpisodes = s.watchedEpisodes,
+                    TotalEpisodes = s.totalEpisodes,
+                    Rating = s.rating,
+                })
+                .ToList();
+
+            await journal.UpsertShows(uc.Id, journalShows);
+            _logger.LogInformation("Journal: stored {0} shows for {1}", journalShows.Count, uc.Name);
+
+            var withEpisodes = profileShows.Where(s => s.show != null && s.watchedEpisodes > 0).ToList();
+            for (var i = 0; i < withEpisodes.Count; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+                var s = withEpisodes[i];
+                IReadOnlyList<ProfileEpisode> episodes;
+                try
+                {
+                    episodes = await api.GetEpisodesByShowId(uc, s.show.id);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Journal: failed to fetch episodes for show {0} ({1})", s.show.id, s.show.title);
+                    continue;
+                }
+
+                var seByEpisodeId = new Dictionary<int, (int Season, int Episode)>();
+                try
+                {
+                    var full = await api.GetShowWithEpisodesById(uc, s.show.id);
+                    if (full?.episodes != null)
+                    {
+                        foreach (var fe in full.episodes)
+                        {
+                            seByEpisodeId[fe.id] = (fe.seasonNumber, fe.episodeNumber);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Journal: failed to fetch full show {0} ({1}) for S/E mapping", s.show.id, s.show.title);
+                }
+
+                var journalEpisodes = episodes
+                    .Where(e => seByEpisodeId.ContainsKey(e.id))
+                    .Select(e => new JournalEpisode
+                    {
+                        EpisodeId = e.id,
+                        ShowId = s.show.id,
+                        SeasonNumber = seByEpisodeId[e.id].Season,
+                        EpisodeNumber = seByEpisodeId[e.id].Episode,
+                        WatchDate = ParseWatchDate(e.watchDate),
+                        Rating = e.rating,
+                        IsFavorite = e.isFavorite,
+                    })
+                    .ToList();
+
+                await journal.UpsertEpisodes(uc.Id, s.show.id, journalEpisodes);
+                progress?.Report(slotStart + slotSize * ((double)(i + 1) / withEpisodes.Count));
+            }
+
+            _logger.LogInformation("Journal: synced episodes for {0} shows of {1}", withEpisodes.Count, uc.Name);
+            progress?.Report(slotStart + slotSize);
+        }
+
+        private static DateTimeOffset? ParseWatchDate(string raw)
+        {
+            if (string.IsNullOrEmpty(raw)) return null;
+            return DateTimeOffset.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var dt)
+                ? dt
+                : (DateTimeOffset?)null;
         }
 
         private async Task PullEpisodes(IMyShowsApi api, UserConfig uc, Jellyfin.Database.Implementations.Entities.User user,
-            IProgress<double> progress, double slotStart, double slotSize, CancellationToken ct)
+            JournalStore journal, IProgress<double> progress, double slotStart, double slotSize, CancellationToken ct)
         {
             var episodes = _libraryManager.GetItemList(new InternalItemsQuery(user)
             {
@@ -122,17 +227,19 @@ namespace MyShows.Tasks
                 var group = bySeries[i];
                 var series = group.First().Series;
 
-                IReadOnlyDictionary<(int Season, int Episode), DateTimeOffset?> watched;
+                int msShowId;
                 try
                 {
-                    watched = await api.GetWatchedEpisodes(uc, series);
+                    msShowId = await api.ResolveMyShowsShowId(uc, series);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Failed to fetch watched episodes for '{0}'", series.Name);
+                    _logger.LogError(ex, "Failed to resolve MyShows id for series '{0}'", series.Name);
                     continue;
                 }
+                if (msShowId <= 0) continue;
 
+                var watched = await journal.GetWatchedEpisodesForShow(uc.Id, msShowId);
                 if (watched.Count == 0) continue;
 
                 foreach (var episode in group)
@@ -154,7 +261,7 @@ namespace MyShows.Tasks
         }
 
         private async Task PullMovies(IMyShowsApi api, UserConfig uc, Jellyfin.Database.Implementations.Entities.User user,
-            IProgress<double> progress, double slotStart, double slotSize, CancellationToken ct)
+            JournalStore journal, IProgress<double> progress, double slotStart, double slotSize, CancellationToken ct)
         {
             var movies = _libraryManager.GetItemList(new InternalItemsQuery(user)
             {
@@ -170,27 +277,64 @@ namespace MyShows.Tasks
                 return;
             }
 
-            IReadOnlyDictionary<Guid, bool> watched;
-            try
+            var myShowsIdToMovie = new Dictionary<int, Movie>();
+            foreach (var movie in movies)
             {
-                watched = await api.GetWatchedMovies(uc, movies);
+                ct.ThrowIfCancellationRequested();
+                int msId;
+                try
+                {
+                    msId = await api.GetMyShowsMovieId(uc, movie);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to resolve MyShows id for movie '{0}'", movie.Name);
+                    continue;
+                }
+                if (msId > 0) myShowsIdToMovie[msId] = movie;
             }
-            catch (Exception ex)
+
+            if (myShowsIdToMovie.Count == 0)
             {
-                _logger.LogError(ex, "Failed to fetch watched movies for {0}", user.Username);
                 progress?.Report(slotStart + slotSize);
                 return;
             }
 
-            ct.ThrowIfCancellationRequested();
-            var marked = 0;
-            foreach (var movie in movies)
+            IReadOnlyList<MovieStatus> statuses;
+            try
             {
-                if (!watched.TryGetValue(movie.Id, out var isWatched) || !isWatched) continue;
-                if (TryMarkPlayed(movie, user, null)) marked++;
+                statuses = await api.GetMovieStatusesByIds(uc, myShowsIdToMovie.Keys.ToArray());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to fetch movie statuses for {0}", user.Username);
+                progress?.Report(slotStart + slotSize);
+                return;
             }
 
-            _logger.LogInformation("Marked {0} movies as played for {1}", marked, user.Username);
+            var journalMovies = new List<JournalMovie>(statuses.Count);
+            var marked = 0;
+            foreach (var status in statuses)
+            {
+                if (!myShowsIdToMovie.TryGetValue(status.id, out var movie)) continue;
+                var isWatched = string.Equals(status.watchStatus, "finished", StringComparison.OrdinalIgnoreCase);
+
+                journalMovies.Add(new JournalMovie
+                {
+                    MovieId = status.id,
+                    TmdbId = movie.GetTmdbId(),
+                    Title = movie.Name,
+                    WatchStatus = status.watchStatus,
+                    WatchDate = null,
+                });
+
+                if (isWatched && TryMarkPlayed(movie, user, null)) marked++;
+            }
+
+            await journal.UpsertMovies(uc.Id, journalMovies);
+
+            _logger.LogInformation("Marked {0} movies as played for {1}; journaled {2}",
+                marked, user.Username, journalMovies.Count);
             progress?.Report(slotStart + slotSize);
         }
 

--- a/MyShows/Tasks/PullWatchedFromMyShowsTask.cs
+++ b/MyShows/Tasks/PullWatchedFromMyShowsTask.cs
@@ -129,6 +129,7 @@ namespace MyShows.Tasks
                     Title = s.show.title,
                     TitleOriginal = s.show.titleOriginal,
                     Year = s.show.year,
+                    TotalSeasons = s.show.totalSeasons,
                     Status = s.show.status,
                     WatchStatus = s.watchStatus,
                     WatchedEpisodes = s.watchedEpisodes,

--- a/MyShows/Tasks/PullWatchedFromMyShowsTask.cs
+++ b/MyShows/Tasks/PullWatchedFromMyShowsTask.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+using MyShows.Configuration;
+using MyShows.MyShowsApi;
+
+namespace MyShows.Tasks
+{
+    public class PullWatchedFromMyShowsTask : IScheduledTask, IConfigurableScheduledTask
+    {
+        private readonly ILibraryManager _libraryManager;
+        private readonly IUserManager _userManager;
+        private readonly IUserDataManager _userDataManager;
+        private readonly ILogger _logger;
+        private readonly MyShowsApiFactory _apiFactory;
+
+        public PullWatchedFromMyShowsTask(
+            ILibraryManager libraryManager,
+            IUserManager userManager,
+            IUserDataManager userDataManager,
+            ILoggerFactory loggerFactory,
+            IHttpClientFactory httpClientFactory)
+        {
+            _libraryManager = libraryManager;
+            _userManager = userManager;
+            _userDataManager = userDataManager;
+            _logger = loggerFactory.CreateLogger("MyShows.PullWatched");
+            _apiFactory = new MyShowsApiFactory(_logger, httpClientFactory);
+        }
+
+        public string Name => "MyShows → Jellyfin: pull watched";
+        public string Key => "MyShowsPullWatched";
+        public string Description => "Backfill played state in Jellyfin from MyShows.me for users configured in the MyShows plugin.";
+        public string Category => "MyShows";
+
+        public bool IsHidden => false;
+        public bool IsEnabled => true;
+        public bool IsLogged => true;
+
+        public IEnumerable<TaskTriggerInfo> GetDefaultTriggers() => Array.Empty<TaskTriggerInfo>();
+
+        public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+        {
+            var config = Plugin.Instance?.PluginConfiguration;
+            if (config?.Users == null || config.Users.Length == 0)
+            {
+                _logger.LogInformation("No MyShows users configured, nothing to pull");
+                progress?.Report(100);
+                return;
+            }
+
+            var userConfigs = config.Users
+                .Where(u => !string.IsNullOrEmpty(u.AccessToken) && u.PullWatchedFromMyShows)
+                .ToList();
+            if (userConfigs.Count == 0)
+            {
+                _logger.LogInformation("No MyShows users opted in to pull-sync (PullWatchedFromMyShows=true), nothing to do");
+                progress?.Report(100);
+                return;
+            }
+
+            for (var i = 0; i < userConfigs.Count; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var uc = userConfigs[i];
+                await ProcessUser(uc, progress, i, userConfigs.Count, cancellationToken);
+            }
+
+            progress?.Report(100);
+        }
+
+        private async Task ProcessUser(UserConfig uc, IProgress<double> progress, int userIndex, int userCount, CancellationToken ct)
+        {
+            var jellyfinUser = ResolveJellyfinUser(uc);
+            if (jellyfinUser == null)
+            {
+                _logger.LogWarning("Cannot resolve Jellyfin user for UserConfig id={0}", uc.Id);
+                return;
+            }
+
+            _logger.LogInformation("Pulling watched state for user {0}", jellyfinUser.Username);
+            var api = _apiFactory.GetApi(uc.ApiVersion);
+
+            var userOffset = (double)userIndex / userCount * 100.0;
+            var userSlot = 100.0 / userCount;
+
+            await PullEpisodes(api, uc, jellyfinUser, progress, userOffset, userSlot * 0.7, ct);
+            await PullMovies(api, uc, jellyfinUser, progress, userOffset + userSlot * 0.7, userSlot * 0.3, ct);
+        }
+
+        private async Task PullEpisodes(IMyShowsApi api, UserConfig uc, Jellyfin.Database.Implementations.Entities.User user,
+            IProgress<double> progress, double slotStart, double slotSize, CancellationToken ct)
+        {
+            var episodes = _libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = new[] { BaseItemKind.Episode },
+                Recursive = true,
+                IsVirtualItem = false,
+            }).OfType<Episode>().Where(IsEpisodeMappable).ToList();
+
+            var bySeries = episodes
+                .Where(e => e.Series != null)
+                .GroupBy(e => e.Series.Id)
+                .ToList();
+
+            _logger.LogInformation("Found {0} episodes across {1} series for {2}", episodes.Count, bySeries.Count, user.Username);
+
+            var marked = 0;
+            for (var i = 0; i < bySeries.Count; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+                var group = bySeries[i];
+                var series = group.First().Series;
+
+                IReadOnlyDictionary<(int Season, int Episode), DateTimeOffset?> watched;
+                try
+                {
+                    watched = await api.GetWatchedEpisodes(uc, series);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to fetch watched episodes for '{0}'", series.Name);
+                    continue;
+                }
+
+                if (watched.Count == 0) continue;
+
+                foreach (var episode in group)
+                {
+                    if (episode.Season?.IndexNumber == null || !episode.IndexNumber.HasValue) continue;
+                    var key = (episode.Season.IndexNumber.Value, episode.IndexNumber.Value);
+                    if (!watched.TryGetValue(key, out var when)) continue;
+
+                    if (TryMarkPlayed(episode, user, when))
+                    {
+                        marked++;
+                    }
+                }
+
+                progress?.Report(slotStart + slotSize * ((double)(i + 1) / bySeries.Count));
+            }
+
+            _logger.LogInformation("Marked {0} episodes as played for {1}", marked, user.Username);
+        }
+
+        private async Task PullMovies(IMyShowsApi api, UserConfig uc, Jellyfin.Database.Implementations.Entities.User user,
+            IProgress<double> progress, double slotStart, double slotSize, CancellationToken ct)
+        {
+            var movies = _libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = new[] { BaseItemKind.Movie },
+                Recursive = true,
+                IsVirtualItem = false,
+            }).OfType<Movie>().Where(m => !string.IsNullOrEmpty(m.GetTmdbId())).ToList();
+
+            _logger.LogInformation("Found {0} movies with TMDb id for {1}", movies.Count, user.Username);
+            if (movies.Count == 0)
+            {
+                progress?.Report(slotStart + slotSize);
+                return;
+            }
+
+            IReadOnlyDictionary<Guid, bool> watched;
+            try
+            {
+                watched = await api.GetWatchedMovies(uc, movies);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to fetch watched movies for {0}", user.Username);
+                progress?.Report(slotStart + slotSize);
+                return;
+            }
+
+            ct.ThrowIfCancellationRequested();
+            var marked = 0;
+            foreach (var movie in movies)
+            {
+                if (!watched.TryGetValue(movie.Id, out var isWatched) || !isWatched) continue;
+                if (TryMarkPlayed(movie, user, null)) marked++;
+            }
+
+            _logger.LogInformation("Marked {0} movies as played for {1}", marked, user.Username);
+            progress?.Report(slotStart + slotSize);
+        }
+
+        private bool TryMarkPlayed(BaseItem item, Jellyfin.Database.Implementations.Entities.User user, DateTimeOffset? when)
+        {
+            var existing = _userDataManager.GetUserData(user, item);
+            if (existing != null && existing.Played) return false;
+
+            var datePlayed = when?.UtcDateTime ?? DateTime.UtcNow;
+            item.MarkPlayed(user, datePlayed, true);
+            _logger.LogDebug("Marked played: {0}", item.Name);
+            return true;
+        }
+
+        private Jellyfin.Database.Implementations.Entities.User ResolveJellyfinUser(UserConfig uc)
+        {
+            if (string.IsNullOrEmpty(uc.Id)) return null;
+            if (!Guid.TryParseExact(uc.Id, "N", out var guid)) return null;
+            return _userManager.GetUserById(guid);
+        }
+
+        private static bool IsEpisodeMappable(Episode episode)
+        {
+            if (episode == null || episode.Series == null) return false;
+            if (episode.Season?.IndexNumber == null) return false;
+            if (!episode.IndexNumber.HasValue) return false;
+            var (_, source) = episode.Series.GetBestProviderId();
+            return source != null;
+        }
+    }
+}

--- a/MyShows/Tasks/PullWatchedFromMyShowsTask.cs
+++ b/MyShows/Tasks/PullWatchedFromMyShowsTask.cs
@@ -344,6 +344,7 @@ namespace MyShows.Tasks
             if (existing != null && existing.Played) return false;
 
             var datePlayed = when?.UtcDateTime ?? DateTime.UtcNow;
+            ScrobbleSuppressor.Suppress(user.Id, item.Id);
             item.MarkPlayed(user, datePlayed, true);
             _logger.LogDebug("Marked played: {0}", item.Name);
             return true;

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MyShows.me integration for Jellyfin.
 
 This is a fork of [shemanaev/jellyfin-plugin-myshows](https://github.com/shemanaev/jellyfin-plugin-myshows) with extra features:
 
-- **Movies scrobbling** via TMDb provider id (upstream only handles episodes).
+- **Movies scrobbling** via TMDb id **or** KinoPoisk id (upstream only handles episodes; only TMDb in pre-5.4.2).
 - **MyShows API v3 RPC** endpoint (`myshows.me/v3/rpc/`) with `Authorization2: Bearer ...` header. Upstream still uses v2 (`api.myshows.me/v2/rpc/`).
 - **Pull-sync scheduled task** — backfills `Played` state in Jellyfin from MyShows.me for opted-in users (`UserConfig.PullWatchedFromMyShows = true`). Runs manually from Dashboard → Scheduled Tasks → category "MyShows".
 - Built against **.NET 9** / **Jellyfin 10.11.x** (upstream is on .NET 8 / Jellyfin 10.9.x).
@@ -23,7 +23,19 @@ To opt-in to pull-sync, set `<PullWatchedFromMyShows>true</PullWatchedFromMyShow
 
 ### Movies — requirements
 
-Movies are matched by **TMDb id only** — MyShows does not accept other movie ID sources via `movies.AddExternalMovie`. Make sure Jellyfin's TMDb metadata provider is enabled and your movies have a TMDb provider id.
+Movies are matched by **TMDb id** first, then **KinoPoisk id** as fallback (since 5.4.2). MyShows `movies.AddExternalMovie` accepts `source` values `tmdb`, `imdb`, `kinopoisk` (this fork uses `tmdb` and `kinopoisk`). Make sure at least one of TMDb / KinoPoisk metadata providers is enabled and matches your movies.
+
+If neither provider id is present, the plugin silently skips scrobbling (since both `OnPlaybackProgress` and `OnPlaybackStopped` need an external id to map the Jellyfin movie to a MyShows.me record). Use the REST endpoint below to find such movies.
+
+### REST endpoints
+
+All under `Authorization` (Jellyfin `X-Emby-Token` or session token).
+
+- `GET /MyShows/v1/history/stats?topShows=N&userId=<guid>` — stats from the local SQLite journal (see [Pull-sync](#pull-sync)).
+- `GET /MyShows/v1/history/episodes/recent?limit=N&userId=<guid>` — latest watched episodes.
+- `GET /MyShows/v1/history/shows/recent?limit=N&userId=<guid>` — latest watched shows.
+- `GET /MyShows/v1/history/movies?limit=N&onlyFinished=true&userId=<guid>` — watched movies.
+- `GET /MyShows/v1/library/movies/unscrobblable` — movies in your library that MyShows/Trakt cannot scrobble (no TMDb id) plus movies that only have a KinoPoisk id (scrobble-able since 5.4.2 but Trakt will still skip them). Useful for monitoring identification gaps.
 
 ### Network access to MyShows
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,34 @@
-# jellyfin-plugin-myshows
-MyShows.me integration for Jellyfin
+# jellyfin-plugin-myshows (slartus fork)
+
+MyShows.me integration for Jellyfin.
+
+This is a fork of [shemanaev/jellyfin-plugin-myshows](https://github.com/shemanaev/jellyfin-plugin-myshows) with extra features:
+
+- **Movies scrobbling** via TMDb provider id (upstream only handles episodes).
+- **MyShows API v3 RPC** endpoint (`myshows.me/v3/rpc/`) with `Authorization2: Bearer ...` header. Upstream still uses v2 (`api.myshows.me/v2/rpc/`).
+- **Pull-sync scheduled task** — backfills `Played` state in Jellyfin from MyShows.me for opted-in users (`UserConfig.PullWatchedFromMyShows = true`). Runs manually from Dashboard → Scheduled Tasks → category "MyShows".
+- Built against **.NET 9** / **Jellyfin 10.11.x** (upstream is on .NET 8 / Jellyfin 10.9.x).
 
 ## Installation
 
-Add repository with my plugins from [jellyfin-plugin-repo](https://github.com/shemanaev/jellyfin-plugin-repo).
+Build locally (`dotnet build -c Release`) and drop `MyShows.dll` into a new folder under `<jellyfin-config>/plugins/MyShows_<version>/` together with `meta.json` and `myshows.png`.
 
+The upstream `jellyfin-plugin-repo` does not host this fork; install manually.
 
 ## Configuration
 
-Plugin's configuration tied to jellyfin user, so each have own MyShows credentials.
+Plugin configuration is tied to a Jellyfin user — each user has their own MyShows credentials. Admin rights are required to configure the plugin from the dashboard.
 
-User must have admin rights to be able to configure plugin in dashboard.
+To opt-in to pull-sync, set `<PullWatchedFromMyShows>true</PullWatchedFromMyShows>` for the desired `UserConfig` in `<jellyfin-config>/plugins/configurations/MyShows.xml`. Default is `false` to avoid surprises on upgrade.
 
+### Movies — requirements
+
+Movies are matched by **TMDb id only** — MyShows does not accept other movie ID sources via `movies.AddExternalMovie`. Make sure Jellyfin's TMDb metadata provider is enabled and your movies have a TMDb provider id.
+
+### Network access to MyShows
+
+`myshows.me` may be blocked by DPI/SNI filtering at some ISPs. If Jellyfin can't reach the host, route the container through a proxy (e.g. xray, sing-box) via `HTTP_PROXY`/`HTTPS_PROXY` environment variables.
 
 ## Debugging
 
-Define `JellyfinHome` environment variable pointing to Jellyfin distribution to be able to run debug configuration.
+Define the `JellyfinHome` environment variable pointing to a Jellyfin distribution to be able to run the debug configuration.

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "MyShows"
 guid: "ef35f6b1-7fe6-44ca-a215-232089fb9bc7"
-version: "5.4.0.0"
+version: "5.4.0.1"
 targetAbi: "10.11.11.0"
 framework: "net9.0"
 overview: "Scrobble your watched shows and movies with MyShows.me"
@@ -12,6 +12,5 @@ owner: "slartus"
 artifacts:
   - "MyShows.dll"
 changelog: >
-  Add local watch journal (SQLite) populated by pull-task; expose GET /MyShows/v1/history/{stats,episodes/recent}
-  REST endpoints for external readers (homelab-bot, etc.). Switch PullEpisodes to journal-backed lookup
-  to remove N+1 RPC at scale.
+  Patch: suppress echo-scrobble from pull-task (MarkPlayed -> UserDataSaved -> Scrobbler push-back).
+  Pull-task no longer triggers redundant CheckEpisode/SyncEpisodesDelta RPC for items it just marked.

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "MyShows"
 guid: "ef35f6b1-7fe6-44ca-a215-232089fb9bc7"
-version: "5.4.0.1"
+version: "5.4.1.0"
 targetAbi: "10.11.11.0"
 framework: "net9.0"
 overview: "Scrobble your watched shows and movies with MyShows.me"
@@ -12,5 +12,5 @@ owner: "slartus"
 artifacts:
   - "MyShows.dll"
 changelog: >
-  Patch: suppress echo-scrobble from pull-task (MarkPlayed -> UserDataSaved -> Scrobbler push-back).
-  Pull-task no longer triggers redundant CheckEpisode/SyncEpisodesDelta RPC for items it just marked.
+  Add /MyShows/v1/history/shows/recent (sorted by last watched episode) and /history/movies
+  endpoints for journal readers.

--- a/build.yaml
+++ b/build.yaml
@@ -1,9 +1,9 @@
 ---
 name: "MyShows"
 guid: "ef35f6b1-7fe6-44ca-a215-232089fb9bc7"
-version: "5.2.0.0"
-targetAbi: "10.9.0.0"
-framework: "net8.0"
+version: "5.3.0.0"
+targetAbi: "10.11.11.0"
+framework: "net9.0"
 overview: "Scrobble your watched shows and movies with MyShows.me"
 description: >
   Scrobble your watched shows and movies with MyShows.me.
@@ -12,4 +12,5 @@ owner: "slartus"
 artifacts:
   - "MyShows.dll"
 changelog: >
-  Add movie scrobbling via TMDb provider id. Switched API endpoint to v3.
+  Add scheduled task "MyShows -> Jellyfin: pull watched" that backfills played state in Jellyfin
+  from MyShows.me for users configured in the plugin.

--- a/build.yaml
+++ b/build.yaml
@@ -1,15 +1,15 @@
 ---
 name: "MyShows"
 guid: "ef35f6b1-7fe6-44ca-a215-232089fb9bc7"
-version: "5.1.0.0"
+version: "5.2.0.0"
 targetAbi: "10.9.0.0"
 framework: "net8.0"
-overview: "Scrobble your watched shows with MyShows.me"
+overview: "Scrobble your watched shows and movies with MyShows.me"
 description: >
-  Scrobble your watched shows with MyShows.me.
+  Scrobble your watched shows and movies with MyShows.me.
 category: "General"
-owner: "shemanaev"
+owner: "slartus"
 artifacts:
   - "MyShows.dll"
 changelog: >
-  Update for 10.9 compatibility
+  Add movie scrobbling via TMDb provider id. Switched API endpoint to v3.

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "MyShows"
 guid: "ef35f6b1-7fe6-44ca-a215-232089fb9bc7"
-version: "5.3.0.0"
+version: "5.4.0.0"
 targetAbi: "10.11.11.0"
 framework: "net9.0"
 overview: "Scrobble your watched shows and movies with MyShows.me"
@@ -12,5 +12,6 @@ owner: "slartus"
 artifacts:
   - "MyShows.dll"
 changelog: >
-  Add scheduled task "MyShows -> Jellyfin: pull watched" that backfills played state in Jellyfin
-  from MyShows.me for users configured in the plugin.
+  Add local watch journal (SQLite) populated by pull-task; expose GET /MyShows/v1/history/{stats,episodes/recent}
+  REST endpoints for external readers (homelab-bot, etc.). Switch PullEpisodes to journal-backed lookup
+  to remove N+1 RPC at scale.

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "MyShows"
 guid: "ef35f6b1-7fe6-44ca-a215-232089fb9bc7"
-version: "5.4.1.0"
+version: "5.4.2.0"
 targetAbi: "10.11.11.0"
 framework: "net9.0"
 overview: "Scrobble your watched shows and movies with MyShows.me"
@@ -12,5 +12,6 @@ owner: "slartus"
 artifacts:
   - "MyShows.dll"
 changelog: >
-  Add /MyShows/v1/history/shows/recent (sorted by last watched episode) and /history/movies
-  endpoints for journal readers.
+  Movies now scrobble via KinoPoisk id when TMDb id is missing
+  (was: silent skip). New endpoint GET /MyShows/v1/library/movies/unscrobblable
+  to surface movies the plugin cannot identify.


### PR DESCRIPTION
## Что и зачем

В форке плагин раньше скробблил фильмы только по `TMDb id`. Для свежих RU-релизов без TMDb-метаданных (только KinoPoisk) `Scrobbler.CanSync` возвращал `false`, и оба handler'а — `OnPlaybackProgress` и `OnUserDataSaved` — молча скипали скроббл. В логе появлялись только строки `MyShows: Playback Started` и `MyShows: Playback Stopped`, ни одного предупреждения. Пользователь был вынужден ставить флаг вручную на myshows.me.

Конкретный кейс, спровоцировавший фикс: фильм «Грязные деньги» (`Gryaznye.dengi.2026.AMZN.WEB-DLRip.AVC.mkv`), 96 минут просмотра 22.06.2026 — ни MyShows, ни Trakt не пометили.

## Изменения

- `Extensions.GetKinopoiskId()` + `GetBestMovieExternalId()` — единая точка получения id для фильма (TMDb → KinoPoisk).
- `Scrobbler.CanSync(Movie)` теперь принимает фильм с любым из {TMDb, KinoPoisk}.
- `MyShowsApi20.GetMovieId` сначала пробует `source="tmdb"`, при отсутствии — `source="kinopoisk"`. Это значение MyShows.tv swagger явно поддерживает в схеме `shows.GetByExternalId_RequestBody`.
- `PullWatchedFromMyShowsTask.PullMovies` фильтр расширен с TMDb-only до TMDb-или-KP.
- **Новый эндпоинт `GET /MyShows/v1/library/movies/unscrobblable`** возвращает список фильмов библиотеки, разделённый на:
  - `noExternalIdItems` — без TMDb и без KP: ни MyShows, ни Trakt не скробблят, нужен ручной Identify.
  - `kinopoisk OnlyItems` — только KP id: MyShows-плагин (5.4.2+) теперь скробблит через KP, Trakt всё равно skip.
- Version bump `5.4.1.0 → 5.4.2.0`.

## Совместимость

- Существующие фильмы с TMDb id ведут себя ровно как раньше (TMDb пробуется первым).
- Кэш movies изменил формат ключа `tmdb:<id>` → `<source>:<id>` — это означает что для уже закешированных фильмов первое обращение после апдейта сделает один лишний RPC к MyShows. Не критично.

## Test plan

- [ ] Воспроизведение фильма с TMDb id → как раньше, `Item is played 90%. Scrobble` → `Checked movie ... successfully`.
- [ ] Воспроизведение фильма только с KP id → `Checked movie ... successfully` (раньше silent skip).
- [ ] Фильм без обоих id → лог `No TMDb/KinoPoisk id for movie '...' — MyShows cannot match it`.
- [ ] `GET /MyShows/v1/library/movies/unscrobblable` с admin-токеном → JSON с массивами.

🤖 Generated with [Claude Code](https://claude.com/claude-code)